### PR TITLE
Wrap the header search paths in quotes

### DIFF
--- a/build-mac/mailcore2.xcodeproj/project.pbxproj
+++ b/build-mac/mailcore2.xcodeproj/project.pbxproj
@@ -1212,6 +1212,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
+				HEADER_SEARCH_PATHS = (
+					"\"$(SRCROOT)/../Externals/libetpan/include\"",
+					"\"$(SRCROOT)/../Externals/icu4c/include\"",
+					"\"$(SRCROOT)/../Externals/ctemplate/include\"",
+					/usr/include/tidy,
+					/usr/include/libxml2,
+				);
 				PRODUCT_NAME = mailcore2;
 			};
 			name = Debug;
@@ -1220,6 +1227,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				EXECUTABLE_PREFIX = lib;
+				HEADER_SEARCH_PATHS = (
+					"\"$(SRCROOT)/../Externals/libetpan/include\"",
+					"\"$(SRCROOT)/../Externals/icu4c/include\"",
+					"\"$(SRCROOT)/../Externals/ctemplate/include\"",
+					/usr/include/tidy,
+					/usr/include/libxml2,
+				);
 				PRODUCT_NAME = mailcore2;
 			};
 			name = Release;


### PR DESCRIPTION
This solves an issue where the paths didn't work when the project was stored in a directory that contained a space in the path.
