### PR TITLE
brought forward some MCString methods to ObjC interface

### DIFF
--- a/src/objc/utils/NSString+MCO.h
+++ b/src/objc/utils/NSString+MCO.h
@@ -28,6 +28,13 @@ namespace mailcore {
 - (mailcore::String *) mco_mcString;
 #endif
 
+- (NSString *) mco_flattenHTML;
+- (NSString *) mco_flattenHTMLAndShowBlockquote:(BOOL)showBlockquote;
+- (NSString *) mco_flattenHTMLAndShowBlockquote:(BOOL)showBlockquote showLink:(BOOL)showLink;
+
+- (NSString *) mco_htmlEncodedString;
+- (NSString *) mco_cleanedHTMLString;
+
 @end
 
 #endif

--- a/src/objc/utils/NSString+MCO.mm
+++ b/src/objc/utils/NSString+MCO.mm
@@ -39,4 +39,31 @@
     return mailcore::String::stringWithCharacters(characters, (unsigned int) [self length]);
 }
 
+- (NSString *) mco_flattenHTML
+{
+	return [NSString mco_stringWithMCString:[self mco_mcString]->flattenHTML()];
+}
+
+- (NSString *) mco_flattenHTMLAndShowBlockquote:(BOOL)showBlockquote
+{
+	return [NSString mco_stringWithMCString:[self mco_mcString]->flattenHTMLAndShowBlockquote(showBlockquote)];
+}
+
+- (NSString *) mco_flattenHTMLAndShowBlockquote:(BOOL)showBlockquote showLink:(BOOL)showLink
+{
+	return [NSString mco_stringWithMCString:[self mco_mcString]->flattenHTMLAndShowBlockquoteAndLink(showBlockquote, showLink)];
+}
+
+
+- (NSString *) mco_htmlEncodedString
+{
+	return [NSString mco_stringWithMCString:[self mco_mcString]->htmlEncodedString()];
+}
+
+- (NSString *) mco_cleanedHTMLString
+{
+	return [NSString mco_stringWithMCString:[self mco_mcString]->cleanedHTMLString()];
+}
+
+
 @end


### PR DESCRIPTION
I added the following methods to the NSString (MCO) category.
- (NSString *) mco_flattenHTML;
- (NSString *) mco_flattenHTMLAndShowBlockquote:(BOOL)showBlockquote;
- (NSString *) mco_flattenHTMLAndShowBlockquote:(BOOL)showBlockquote showLink:(BOOL)showLink;
- (NSString *) mco_htmlEncodedString;
- (NSString *) mco_cleanedHTMLString;
