### PR TITLE
Fixed the crashes while using the MCIMAPSearchExpression, mKind was not set and missing mco_mcObject function

### DIFF
--- a/src/core/imap/MCIMAPSearchExpression.cc
+++ b/src/core/imap/MCIMAPSearchExpression.cc
@@ -19,7 +19,7 @@ IMAPSearchExpression::IMAPSearchExpression()
 IMAPSearchExpression::IMAPSearchExpression(IMAPSearchExpression * other)
 {
     init();
-	mKind = IMAPSearchKindNone;
+	mKind = other->mKind;
     MC_SAFE_REPLACE_COPY(String, mHeader, other->mHeader);
     MC_SAFE_REPLACE_COPY(String, mValue, other->mValue);
     MC_SAFE_REPLACE_COPY(IMAPSearchExpression, mLeftExpression, other->mLeftExpression);

--- a/src/objc/imap/MCOIMAPSearchExpression.mm
+++ b/src/objc/imap/MCOIMAPSearchExpression.mm
@@ -37,6 +37,11 @@
     return [[[self alloc] initWithMCExpression:expr] autorelease];
 }
 
+- (mailcore::Object *) mco_mcObject
+{
+    return _nativeExpr;
+}
+
 - (id) initWithMCExpression:(mailcore::IMAPSearchExpression *)expr
 {
     self = [super init];


### PR DESCRIPTION
...set and missing mco_mcObject function

My Code still crashes inside libetpan at condstore.c:473, I am not sure if this is related to 

https://github.com/dinhviethoa/libetpan/issues/68
