### PR TITLE
IMAPFolderInfoOperation assert

### DIFF
--- a/src/async/imap/MCIMAPFolderInfoOperation.cc
+++ b/src/async/imap/MCIMAPFolderInfoOperation.cc
@@ -48,7 +48,7 @@ int IMAPFolderInfoOperation::messageCount()
 void IMAPFolderInfoOperation::main()
 {
     ErrorCode error;
-    session()->session()->select(folder(), &error);
+    session()->session()->selectIfNeeded(folder(), &error);
     mUidNext = session()->session()->uidNext();
     mUidValidity = session()->session()->uidValidity();
     mModSequenceValue = session()->session()->modSequenceValue();

--- a/src/core/imap/MCIMAPSession.h
+++ b/src/core/imap/MCIMAPSession.h
@@ -59,6 +59,7 @@ namespace mailcore {
 		virtual void setDefaultNamespace(IMAPNamespace * ns);
 		virtual IMAPNamespace * defaultNamespace();
 
+        virtual void selectIfNeeded(String * folder, ErrorCode * pError);
 		virtual void select(String * folder, ErrorCode * pError);
 		
 		virtual Array * /* IMAPFolder */ fetchSubscribedFolders(ErrorCode * pError);
@@ -172,7 +173,6 @@ namespace mailcore {
 		void unsetup();
 		void connectIfNeeded(ErrorCode * pError);
 		void loginIfNeeded(ErrorCode * pError);
-		void selectIfNeeded(String * folder, ErrorCode * pError);
 		char fetchDelimiterIfNeeded(char defaultDelimiter, ErrorCode * pError);
 		IMAPSyncResult * fetchMessages(String * folder, IMAPMessagesRequestKind requestKind, bool fetchByUID,
                                        struct mailimap_set * imapset, uint64_t modseq, HashMap * mapping, uint32_t startUid,


### PR DESCRIPTION
Hi,

When running an IMAPFolderInfoOperation I consistently get the following assert.

MCIMAPSession.cc:813: assert mState == STATE_LOGGEDIN || mState == STATE_SELECTED

Using selectIfNeeded instead of select in IMAPFolderInfoOperation::main() seems to fix this issue. Any thoughts on this?
