### PR TITLE
Fix crash caused by empty html from message builder

### DIFF
--- a/src/core/basetypes/MCString.cc
+++ b/src/core/basetypes/MCString.cc
@@ -1224,7 +1224,9 @@ unsigned int String::replaceOccurrencesOfString(String * occurrence, String * re
         dest_p += replacement->length();
     }
     // copy remaining
-    u_strcpy(dest_p, p);
+    if(p) {
+    	u_strcpy(dest_p, p);	
+    }
     
     free(mUnicodeChars);
     mUnicodeChars = unicodeChars;


### PR DESCRIPTION
Fix crash when flatten was eventually called on empty html string from MessageBuilder.
