### PR TITLE
Updated fetchMessagesByNumberOperationWithFolder documentation

### DIFF
--- a/src/objc/imap/MCOIMAPSession.h
+++ b/src/objc/imap/MCOIMAPSession.h
@@ -310,7 +310,7 @@
     
      [folderInfo start:^(NSError *error, MCOIMAPFolderInfo *info) {
          int messageCount = [info messageCount];
-         int numberOfMessages = 5;
+         int numberOfMessages = 50;
          MCOIndexSet *numbers = [MCOIndexSet indexSetWithRange:MCORangeMake(messageCount - numberOfMessages, numberOfMessages)];
         
          MCOIMAPFetchMessagesOperation *fetchOperation = [session fetchMessagesByNumberOperationWithFolder:folder


### PR DESCRIPTION
I updated this to fix issues with the original example, and to provide information on how to get the message count.
