### PR TITLE
Fix for MCMessageBuilder copy constructor

### DIFF
--- a/src/core/rfc822/MCMessageBuilder.cc
+++ b/src/core/rfc822/MCMessageBuilder.cc
@@ -478,7 +478,7 @@ MessageBuilder::MessageBuilder(MessageBuilder * other)
 {
     init();
     setHTMLBody(other->mHTMLBody);
-    setHTMLBody(other->mTextBody);
+    setTextBody(other->mTextBody);
     setAttachments(other->mAttachments);
     setRelatedAttachments(other->mRelatedAttachments);
     MC_SAFE_REPLACE_COPY(String, mBoundaryPrefix, other->mBoundaryPrefix);

--- a/tests/test-all.mm
+++ b/tests/test-all.mm
@@ -67,7 +67,13 @@ static mailcore::Data * testMessageBuilder()
     
     MCLog("%s", data->bytes());
     
+    mailcore::MessageBuilder * msg2 = new mailcore::MessageBuilder(msg);
+    mailcore::String *htmlBody = msg->htmlBody();
+    mailcore::String *htmlBody2 = msg2->htmlBody();
+    MCAssert(htmlBody->isEqual(htmlBody2));
+    
     msg->release();
+    msg2->release();
     
     return data;
 }


### PR DESCRIPTION
Fix for HTML body being overwritten with text body.
