### PR TITLE
Messing around with adding compression flag, WIP

### DIFF
--- a/build-mac/mailcore2.xcodeproj/project.pbxproj
+++ b/build-mac/mailcore2.xcodeproj/project.pbxproj
@@ -692,6 +692,9 @@
 		DAE42E89178F7E1800E0DB8F /* MCOIMAPMessageRenderingOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA89896B178A47D200F6D90A /* MCOIMAPMessageRenderingOperation.h */; };
 		DAE42E8A178F7E2200E0DB8F /* MCOIMAPMessageRenderingOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA89896B178A47D200F6D90A /* MCOIMAPMessageRenderingOperation.h */; };
 		F87F190C16BB62B00012652F /* MCOIMAPFetchFoldersOperation.mm in Sources */ = {isa = PBXBuildFile; fileRef = F87F190B16BB62B00012652F /* MCOIMAPFetchFoldersOperation.mm */; };
+		F895C0231797078E00696A81 /* MCIMAPEnableCompressionOperation.cc in Sources */ = {isa = PBXBuildFile; fileRef = F895C0211797078C00696A81 /* MCIMAPEnableCompressionOperation.cc */; };
+		F895C0241797078E00696A81 /* MCIMAPEnableCompressionOperation.cc in Sources */ = {isa = PBXBuildFile; fileRef = F895C0211797078C00696A81 /* MCIMAPEnableCompressionOperation.cc */; };
+		F895C0251797078E00696A81 /* MCIMAPEnableCompressionOperation.cc in Sources */ = {isa = PBXBuildFile; fileRef = F895C0211797078C00696A81 /* MCIMAPEnableCompressionOperation.cc */; };
 		F8EA941716BB1C9D0011AC6F /* MCOIMAPSession.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = F8EA941416BAED6E0011AC6F /* MCOIMAPSession.h */; };
 /* End PBXBuildFile section */
 
@@ -1489,6 +1492,8 @@
 		DAD28C8A1783CFFC00F2BB8F /* MCHTMLBodyRendererTemplateCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCHTMLBodyRendererTemplateCallback.h; sourceTree = "<group>"; };
 		F87F190816BB62690012652F /* MCOIMAPFetchFoldersOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCOIMAPFetchFoldersOperation.h; sourceTree = "<group>"; };
 		F87F190B16BB62B00012652F /* MCOIMAPFetchFoldersOperation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MCOIMAPFetchFoldersOperation.mm; sourceTree = "<group>"; };
+		F895C0211797078C00696A81 /* MCIMAPEnableCompressionOperation.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MCIMAPEnableCompressionOperation.cc; sourceTree = "<group>"; };
+		F895C0221797078D00696A81 /* MCIMAPEnableCompressionOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCIMAPEnableCompressionOperation.h; sourceTree = "<group>"; };
 		F8EA941416BAED6E0011AC6F /* MCOIMAPSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCOIMAPSession.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1740,6 +1745,8 @@
 				C608167A177635D2001F1018 /* MCIMAPDisconnectOperation.h */,
 				DA0F1C79177C07B300F0D3B4 /* MCIMAPMessageRenderingOperation.cc */,
 				DA0F1C7A177C07B300F0D3B4 /* MCIMAPMessageRenderingOperation.h */,
+				F895C0211797078C00696A81 /* MCIMAPEnableCompressionOperation.cc */,
+				F895C0221797078D00696A81 /* MCIMAPEnableCompressionOperation.h */,
 			);
 			path = imap;
 			sourceTree = "<group>";
@@ -2557,6 +2564,7 @@
 				BD63713B177DFF080094121B /* MCLibetpan.cc in Sources */,
 				DAACAD5117886807000B4517 /* MCHTMLRendererIMAPDataCallback.cc in Sources */,
 				DA89896D178A47D200F6D90A /* MCOIMAPMessageRenderingOperation.mm in Sources */,
+				F895C0231797078E00696A81 /* MCIMAPEnableCompressionOperation.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2746,6 +2754,7 @@
 				BD63713C177DFF080094121B /* MCLibetpan.cc in Sources */,
 				DAACAD5217886807000B4517 /* MCHTMLRendererIMAPDataCallback.cc in Sources */,
 				DA89896E178A47D200F6D90A /* MCOIMAPMessageRenderingOperation.mm in Sources */,
+				F895C0241797078E00696A81 /* MCIMAPEnableCompressionOperation.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2754,6 +2763,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C6BD28AB170BDB6B00A91AC1 /* MCOFramework.mm in Sources */,
+				F895C0251797078E00696A81 /* MCIMAPEnableCompressionOperation.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/async/imap/MCIMAPAsyncConnection.h
+++ b/src/async/imap/MCIMAPAsyncConnection.h
@@ -121,6 +121,8 @@ namespace mailcore {
         
         virtual IMAPCapabilityOperation * capabilityOperation();
         
+        virtual IMAPOperation * enableCompression();
+        
         virtual IMAPMessageRenderingOperation * htmlRenderingOperation(IMAPMessage * message, String * folder);
         virtual IMAPMessageRenderingOperation * htmlBodyRenderingOperation(IMAPMessage * message, String * folder);
         virtual IMAPMessageRenderingOperation * plainTextRenderingOperation(IMAPMessage * message, String * folder);

--- a/src/async/imap/MCIMAPEnableCompressionOperation.cc
+++ b/src/async/imap/MCIMAPEnableCompressionOperation.cc
@@ -1,0 +1,21 @@
+//
+//  MCIMAPEnableCompressionOperation.cpp
+//  mailcore2
+//
+//  Created by Matt Ronge on 7/17/13.
+//  Copyright (c) 2013 MailCore. All rights reserved.
+//
+
+#include "MCIMAPEnableCompressionOperation.h"
+
+#include "MCIMAPAsyncConnection.h"
+#include "MCIMAPSession.h"
+
+using namespace mailcore;
+
+void IMAPEnableCompressionOperation::main()
+{
+    ErrorCode error;
+    session()->session()->enableCompression(&error);
+    setError(error);
+}

--- a/src/async/imap/MCIMAPEnableCompressionOperation.h
+++ b/src/async/imap/MCIMAPEnableCompressionOperation.h
@@ -1,0 +1,26 @@
+//
+//  MCIMAPEnableCompressionOperation.h
+//  mailcore2
+//
+//  Created by Matt Ronge on 7/17/13.
+//  Copyright (c) 2013 MailCore. All rights reserved.
+//
+
+#ifndef __mailcore2__MCIMAPEnableCompressionOperation__
+#define __mailcore2__MCIMAPEnableCompressionOperation__
+
+#include <MailCore/MCIMAPOperation.h>
+
+#ifdef __cplusplus
+
+namespace mailcore {
+    
+    class IMAPEnableCompressionOperation : public IMAPOperation {
+    public: // subclass behavior
+        virtual void main();
+    };
+}
+
+#endif
+
+#endif /* defined(__mailcore2__MCIMAPEnableCompressionOperation__) */

--- a/src/core/abstract/MCMessageConstants.h
+++ b/src/core/abstract/MCMessageConstants.h
@@ -207,6 +207,7 @@ namespace mailcore {
         ErrorDeleteMessage,
         ErrorInvalidAccount,
         ErrorFile,
+        ErrorCompression,
     };
     
     enum PartType {

--- a/src/core/imap/MCIMAPSession.cc
+++ b/src/core/imap/MCIMAPSession.cc
@@ -2657,6 +2657,27 @@ HashMap * IMAPSession::identity(String * vendor, String * name, String * version
     return result;
 }
 
+void IMAPSession::enableCompression(ErrorCode * pError)
+{
+    int r;
+    r = mailimap_compress(mImap);
+	if (r == MAILIMAP_ERROR_STREAM) {
+        * pError = ErrorConnection;
+        return;
+    }
+    else if (r == MAILIMAP_ERROR_PARSE) {
+        * pError = ErrorParse;
+        return;
+    }
+    else if (hasError(r)) {
+        * pError = ErrorCompression;
+        return;
+	}
+    
+    this->mCompressionEnabled = true;
+    * pError = ErrorNone;
+}
+
 void IMAPSession::bodyProgress(unsigned int current, unsigned int maximum)
 {
     if (!mBodyProgressEnabled)
@@ -3064,6 +3085,11 @@ bool IMAPSession::isIdentityEnabled()
 
 bool IMAPSession::isXOAuthEnabled() {
 	return mXOauth2Enabled;
+}
+
+bool IMAPSession::isCompressionEnabled()
+{
+    return mCompressionEnabled;
 }
 
 bool IMAPSession::isDisconnected()

--- a/src/core/imap/MCIMAPSession.h
+++ b/src/core/imap/MCIMAPSession.h
@@ -58,6 +58,9 @@ namespace mailcore {
         virtual void setVoIPEnabled(bool enabled);
         virtual bool isVoIPEnabled();
         
+        virtual void setCompressionEnabled(bool enabled);
+        virtual bool isCompressionEnabled();
+        
         // Needed for fetchSubscribedFolders() and fetchAllFolders().
         virtual void setDelimiter(char delimiter);
         virtual char delimiter();
@@ -155,6 +158,7 @@ namespace mailcore {
         virtual bool isQResyncEnabled();
         virtual bool isIdentityEnabled();
         virtual bool isXOAuthEnabled();
+        virtual bool isCompressionEnabled();
         
         virtual void setConnectionLogger(ConnectionLogger * logger);
         virtual ConnectionLogger * connectionLogger();
@@ -198,6 +202,7 @@ namespace mailcore {
         bool mQResyncEnabled;
         bool mIdentityEnabled;
         bool mXOauth2Enabled;
+        bool mCompressionEnabled;
         String * mWelcomeString;
         bool mNeedsMboxMailWorkaround;
         uint32_t mUIDValidity;
@@ -225,6 +230,7 @@ namespace mailcore {
         void setup();
         void unsetup();
         void selectIfNeeded(String * folder, ErrorCode * pError);
+        void enableCompression(ErrorCode * pError);
         char fetchDelimiterIfNeeded(char defaultDelimiter, ErrorCode * pError);
         IMAPSyncResult * fetchMessages(String * folder, IMAPMessagesRequestKind requestKind,
                                        bool fetchByUID, struct mailimap_set * imapset, uint64_t modseq,

--- a/src/objc/imap/MCOIMAPSession.h
+++ b/src/objc/imap/MCOIMAPSession.h
@@ -507,6 +507,18 @@
 */
 - (MCOIMAPCapabilityOperation *) capabilityOperation;
 
+
+/**
+ Attempts to enable compression of the IMAP stream. Many servers don't support this,
+ check the capabilities first
+ 
+     MCOIMAPOperation * op = [session enableCompressionOperation];
+     [op start:^(NSError * error) {
+     ...
+     }];
+ */
+- (MCOIMAPOperation *) enableCompressionOperation;
+
 /** @name Search Operations */
 
 /**

--- a/src/objc/imap/MCOIMAPSession.mm
+++ b/src/objc/imap/MCOIMAPSession.mm
@@ -362,6 +362,12 @@ MCO_OBJC_SYNTHESIZE_SCALAR(unsigned int, unsigned int, setMaximumConnections, ma
     return MCO_TO_OBJC_OP(coreOp);
 }
 
+- (MCOIMAPOperation *) enableCompressionOperation
+{
+    IMAPOperation * coreOp = MCO_NATIVE_INSTANCE->enableCompressions();
+    return MCO_TO_OBJC_OP(coreOp);
+}
+
 - (void) _logWithSender:(void *)sender connectionType:(MCOConnectionLogType)logType data:(NSData *)data
 {
     _connectionLogger(sender, logType, data);


### PR DESCRIPTION
I started adding support for turning on compression. I set it up as another async op. Right now it doesn't work right with multiple connections, what I need to do is ask the other connections to also enabled compression. Or I could set a BOOL and on the next reconnect turn on compression.

Or should we automatically enable this stuff after a capability request that shows compression support?
