### PR TITLE
add Content-Description to attachment

### DIFF
--- a/src/core/abstract/MCAbstractPart.cc
+++ b/src/core/abstract/MCAbstractPart.cc
@@ -36,6 +36,7 @@ void AbstractPart::init()
     mCharset = NULL;
     mContentID = NULL;
     mContentLocation = NULL;
+    mContentDescription = NULL;
     mInlineAttachment = false;
     mPartType = PartTypeSingle;
 }
@@ -48,6 +49,7 @@ AbstractPart::~AbstractPart()
     MC_SAFE_RELEASE(mCharset);
     MC_SAFE_RELEASE(mContentID);
     MC_SAFE_RELEASE(mContentLocation);
+    MC_SAFE_RELEASE(mContentDescription);
 }
 
 String * AbstractPart::description()
@@ -68,6 +70,9 @@ String * AbstractPart::description()
     }
     if (mContentLocation != NULL) {
         result->appendUTF8Format("content-location: %s\n", mContentLocation->UTF8Characters());
+    }
+    if (mContentDescription != NULL) {
+        result->appendUTF8Format("content-description: %s\n", mContentDescription->UTF8Characters());
     }
     result->appendUTF8Format("inline: %i\n", mInlineAttachment);
     result->appendUTF8Format(">");
@@ -148,6 +153,16 @@ String * AbstractPart::contentLocation()
 void AbstractPart::setContentLocation(String * contentLocation)
 {
     MC_SAFE_REPLACE_COPY(String, mContentLocation, contentLocation);
+}
+
+String * AbstractPart::contentDescription()
+{
+    return mContentDescription;
+}
+
+void AbstractPart::setContentDescription(String * contentDescription)
+{
+    MC_SAFE_REPLACE_COPY(String, mContentDescription, contentDescription);
 }
 
 bool AbstractPart::isInlineAttachment()
@@ -305,6 +320,9 @@ HashMap * AbstractPart::serializable()
     if (contentLocation() != NULL) {
         result->setObjectForKey(MCSTR("contentLocation"), contentLocation());
     }
+    if (contentDescription() != NULL) {
+        result->setObjectForKey(MCSTR("contentDescription"), contentDescription());
+    }
     if (mInlineAttachment) {
         result->setObjectForKey(MCSTR("inlineAttachment"), MCSTR("1"));
     }
@@ -340,6 +358,7 @@ void AbstractPart::importSerializable(HashMap * serializable)
     setCharset((String *) serializable->objectForKey(MCSTR("charset")));
     setContentID((String *) serializable->objectForKey(MCSTR("contentID")));
     setContentLocation((String *) serializable->objectForKey(MCSTR("contentLocation")));
+    setContentDescription((String *) serializable->objectForKey(MCSTR("contentDescription")));
     String * value = (String *) serializable->objectForKey(MCSTR("inlineAttachment"));
     if (value != NULL) {
         if (value->intValue()) {

--- a/src/core/abstract/MCAbstractPart.h
+++ b/src/core/abstract/MCAbstractPart.h
@@ -36,7 +36,10 @@ namespace mailcore {
         
         virtual String * contentLocation();
         virtual void setContentLocation(String * contentLocation);
-        
+
+        virtual String * contentDescription();
+        virtual void setContentDescription(String * contentDescription);
+
         virtual bool isInlineAttachment();
         virtual void setInlineAttachment(bool inlineAttachment);
         
@@ -64,6 +67,7 @@ namespace mailcore {
         String * mCharset;
         String * mContentID;
         String * mContentLocation;
+        String * mContentDescription;
         bool mInlineAttachment;
         PartType mPartType;
         void init();

--- a/src/core/rfc822/MCMessageBuilder.cc
+++ b/src/core/rfc822/MCMessageBuilder.cc
@@ -194,6 +194,7 @@ static struct mailmime * get_other_text_part(const char * mime_type, const char 
 
 static struct mailmime * get_file_part(const char * filename, const char * mime_type, int is_inline,
                                        const char * content_id,
+                                       const char * content_description,
                                        const char * text, size_t length)
 {
 	char * disposition_name;
@@ -204,7 +205,8 @@ static struct mailmime * get_file_part(const char * filename, const char * mime_
 	struct mailmime * mime;
 	struct mailmime_fields * mime_fields;
 	char * dup_content_id;
-	
+    char * dup_content_description;
+
 	disposition_name = NULL;
 	if (filename != NULL) {
 		disposition_name = strdup(filename);
@@ -224,8 +226,11 @@ static struct mailmime * get_file_part(const char * filename, const char * mime_
     dup_content_id = NULL;
     if (content_id != NULL)
         dup_content_id = strdup(content_id);
+    dup_content_description = NULL;
+    if (content_description != NULL)
+        dup_content_description = strdup(content_description);
 	mime_fields = mailmime_fields_new_with_data(encoding,
-												dup_content_id, NULL, disposition, NULL);
+												dup_content_id, dup_content_description, disposition, NULL);
 	mime = part_new_empty(content, mime_fields, NULL, 1);
 	mailmime_set_body_text(mime, (char *) text, length);
 	
@@ -262,6 +267,7 @@ static struct mailmime * mime_from_attachment(Attachment * att)
         mime = get_file_part(att->filename()->encodedMIMEHeaderValue()->bytes(),
             MCUTF8(att->mimeType()), att->isInlineAttachment(),
             MCUTF8(att->contentID()),
+            att->contentDescription()->encodedMIMEHeaderValue()->bytes(),
             data->bytes(), data->length());
     }
     return mime;

--- a/src/objc/abstract/MCOAbstractPart.h
+++ b/src/objc/abstract/MCOAbstractPart.h
@@ -63,6 +63,9 @@ typedef enum {
 /** Returns the value of the Content-Location field of the part.*/
 @property (nonatomic, copy) NSString * contentLocation;
 
+/** Returns the value of the Content-Description field of the part.*/
+@property (nonatomic, copy) NSString * contentDescription;
+
 /** Returns whether the part is an explicit inline attachment.*/
 @property (nonatomic, assign, getter=isInlineAttachment) BOOL inlineAttachment;
 

--- a/src/objc/abstract/MCOAbstractPart.mm
+++ b/src/objc/abstract/MCOAbstractPart.mm
@@ -70,6 +70,7 @@ MCO_OBJC_SYNTHESIZE_STRING(setCharset, charset)
 MCO_OBJC_SYNTHESIZE_STRING(setUniqueID, uniqueID)
 MCO_OBJC_SYNTHESIZE_STRING(setContentID, contentID)
 MCO_OBJC_SYNTHESIZE_STRING(setContentLocation, contentLocation)
+MCO_OBJC_SYNTHESIZE_STRING(setContentDescription, contentDescription)
 MCO_OBJC_SYNTHESIZE_BOOL(setInlineAttachment, isInlineAttachment)
 
 - (MCOAbstractPart *) partForContentID:(NSString *)contentID


### PR DESCRIPTION
I used `contentDescription->encodedMIMEHeaderValue()->bytes()` for `mailmime_fields_new_with_data()`. I followed the following from http://www.ietf.org/rfc/rfc2045.txt:

> 1.  Content-Description Header Field
>    
>    The ability to associate some descriptive information with a given
>    body is often desirable.  For example, it may be useful to mark an
>    "image" body as "a picture of the Space Shuttle Endeavor."  Such text
>    may be placed in the Content-Description header field.  This header
>    field is always optional.
>    
>     description := "Content-Description" ":" *text
>    
>    The description is presumed to be given in the US-ASCII character
>    set, although the mechanism specified in RFC 2047 may be used for
>    non-US-ASCII Content-Description values.

Hope I got it right...
