### PR TITLE
Fix invalid zero-length ranges in IndexSet/MCOIndexSet

### DIFF
--- a/src/core/basetypes/MCIndexSet.cc
+++ b/src/core/basetypes/MCIndexSet.cc
@@ -215,25 +215,28 @@ void IndexSet::addRange(Range range)
     
     mergeRanges(rangeIndex);
     if (rangeIndex > 0) {
-        tryToMergeAdjacentRanges(rangeIndex - 1);
+        if (tryToMergeAdjacentRanges(rangeIndex - 1)) {
+            rangeIndex--; // we've merged ranges (ie mCount has decreased so position is shifted)
+        }
     }
     if (rangeIndex < mCount - 1) {
         tryToMergeAdjacentRanges(rangeIndex);
     }
 }
 
-void IndexSet::tryToMergeAdjacentRanges(unsigned int rangeIndex)
+bool IndexSet::tryToMergeAdjacentRanges(unsigned int rangeIndex)
 {
     if (RangeRightBound(mRanges[rangeIndex]) == UINT64_MAX)
-        return;
+        return false;
     
     if (RangeRightBound(mRanges[rangeIndex]) + 1 != mRanges[rangeIndex + 1].location) {
-        return;
+        return false;
     }
     
     uint64_t right = RangeRightBound(mRanges[rangeIndex + 1]);
     removeRangeIndex(rangeIndex + 1, 1);
     mRanges[rangeIndex].length = right - mRanges[rangeIndex].location + 1;
+    return true;
 }
 
 void IndexSet::mergeRanges(unsigned int rangeIndex)
@@ -346,12 +349,12 @@ String * IndexSet::description()
             result->appendUTF8Format(",");
         }
         if (mRanges[i].length == 1) {
-            result->appendUTF8Format("%llu",
-                                     (unsigned long long) mRanges[i].location);
+            result->appendUTF8Format("[%u] %llu",
+                                     i, (unsigned long long) mRanges[i].location);
         }
         else {
-            result->appendUTF8Format("%llu-%llu",
-                                     (unsigned long long) mRanges[i].location,
+            result->appendUTF8Format("[%u] %llu-%llu",
+                                     i, (unsigned long long) mRanges[i].location,
                                      (unsigned long long) (mRanges[i].location + mRanges[i].length - 1));
         }
     }

--- a/src/core/basetypes/MCIndexSet.h
+++ b/src/core/basetypes/MCIndexSet.h
@@ -61,7 +61,7 @@ namespace mailcore {
         int leftRangeIndexForIndex(uint64_t idx);
         int leftRangeIndexForIndexWithBounds(uint64_t idx, unsigned int left, unsigned int right);
         void mergeRanges(unsigned int rangeIndex);
-        void tryToMergeAdjacentRanges(unsigned int rangeIndex);
+        bool tryToMergeAdjacentRanges(unsigned int rangeIndex);
 	};
 
 }

--- a/src/core/basetypes/MCRange.cc
+++ b/src/core/basetypes/MCRange.cc
@@ -14,6 +14,10 @@ Range mailcore::RangeEmpty = {UINT64_MAX, 0};
 
 Range mailcore::RangeMake(uint64_t location, uint64_t length)
 {
+    if (length == 0)
+    {
+        return RangeEmpty;
+    }
     Range range;
     range.location = location;
     range.length = length;

--- a/src/core/basetypes/MCString.cc
+++ b/src/core/basetypes/MCString.cc
@@ -2019,12 +2019,12 @@ String * String::mUTF7DecodedString()
 
 String * String::substringFromIndex(unsigned int idx)
 {
-    return substringWithRange(RangeMake(idx, length() - idx));
+    return substringWithRange(RangeMake(idx, length() - idx + 1));
 }
 
 String * String::substringToIndex(unsigned int idx)
 {
-    return substringWithRange(RangeMake(0, idx));
+    return substringWithRange(RangeMake(0, idx + 1));
 }
 
 String * String::substringWithRange(Range range)

--- a/src/core/imap/MCIMAPSession.cc
+++ b/src/core/imap/MCIMAPSession.cc
@@ -306,7 +306,7 @@ static IndexSet * indexSetFromSet(struct mailimap_set * imap_set)
             indexSet->addRange(RangeMake(item->set_first, UINT64_MAX));
         }
         else {
-            indexSet->addRange(RangeMake(item->set_first, item->set_last - item->set_first));
+            indexSet->addRange(RangeMake(item->set_first, item->set_last - item->set_first + 1));
         }
     }
     return indexSet;

--- a/src/objc/imap/MCOIMAPSession.h
+++ b/src/objc/imap/MCOIMAPSession.h
@@ -336,8 +336,7 @@
     
      [folderInfo start:^(NSError *error, MCOIMAPFolderInfo *info) {
          int numberOfMessages = 50;
-         numberOfMessages -= 1;
-         MCOIndexSet *numbers = [MCOIndexSet indexSetWithRange:MCORangeMake([info messageCount] - numberOfMessages, numberOfMessages)];
+         MCOIndexSet *numbers = [MCOIndexSet indexSetWithRange:MCORangeMake([info messageCount] - numberOfMessages + 1, numberOfMessages)];
         
          MCOIMAPFetchMessagesOperation *fetchOperation = [session fetchMessagesByNumberOperationWithFolder:folder
                                                                                                requestKind:MCOIMAPMessagesRequestKindUid

--- a/src/objc/utils/MCORange.mm
+++ b/src/objc/utils/MCORange.mm
@@ -19,6 +19,10 @@ MCORange MCORangeEmpty = {UINT64_MAX, 0};
 
 MCORange MCORangeMake(uint64_t location, uint64_t length)
 {
+    if (length == 0)
+    {
+        return MCORangeEmpty;
+    }
     MCORange result;
     result.location = location;
     result.length = length;


### PR DESCRIPTION
This should fix MCOIndexSet/IndexSet so that ranges with zero length aren't used to store single indexes. The C++ API hasn't changed so should be transparent to the rest of the library.
