### PR TITLE
MCAddress.cc: use the correct key name when reading the Address displayName from a HashMap

### DIFF
--- a/src/core/abstract/MCAddress.cc
+++ b/src/core/abstract/MCAddress.cc
@@ -514,7 +514,7 @@ HashMap * Address::serializable()
 void Address::importSerializable(HashMap * serializable)
 {
     setMailbox((String *) serializable->objectForKey(MCSTR("mailbox")));
-    setDisplayName((String *) serializable->objectForKey(MCSTR("mailbox")));
+    setDisplayName((String *) serializable->objectForKey(MCSTR("displayName")));
 }
 
 __attribute__((constructor))


### PR DESCRIPTION
Simple fix.
