### PR TITLE
Separate searches for to, cc and bcc fields and uids

### DIFF
--- a/src/core/abstract/MCMessageConstants.h
+++ b/src/core/abstract/MCMessageConstants.h
@@ -166,9 +166,9 @@ namespace mailcore {
         IMAPSearchKindNone,
         IMAPSearchKindFrom,
         IMAPSearchKindTo,
-        IMAPSearchKindCC,
-        IMAPSearchKindBCC,
-        IMAPSearchKindRecipient,   // Recipient is the combination of To, CC and BCC
+        IMAPSearchKindCc,
+        IMAPSearchKindBcc,
+        IMAPSearchKindRecipient,   // Recipient is the combination of To, Cc and Bcc
         IMAPSearchKindSubject,
         IMAPSearchKindContent,
         IMAPSearchKindUIDs,

--- a/src/core/imap/MCIMAPSearchExpression.cc
+++ b/src/core/imap/MCIMAPSearchExpression.cc
@@ -53,11 +53,11 @@ String * IMAPSearchExpression::description()
         case IMAPSearchKindTo:
         return String::stringWithUTF8Format("<%s:%p To %s>", MCUTF8(className()), this,
             MCUTF8(mValue->description()));
-        case IMAPSearchKindCC:
-        return String::stringWithUTF8Format("<%s:%p CC %s>", MCUTF8(className()), this,
+        case IMAPSearchKindCc:
+        return String::stringWithUTF8Format("<%s:%p Cc %s>", MCUTF8(className()), this,
             MCUTF8(mValue->description()));
-        case IMAPSearchKindBCC:
-        return String::stringWithUTF8Format("<%s:%p BCC %s>", MCUTF8(className()), this,
+        case IMAPSearchKindBcc:
+        return String::stringWithUTF8Format("<%s:%p Bcc %s>", MCUTF8(className()), this,
             MCUTF8(mValue->description()));
         case IMAPSearchKindRecipient:
         return String::stringWithUTF8Format("<%s:%p Recipient %s>", MCUTF8(className()), this,
@@ -107,18 +107,18 @@ IMAPSearchExpression * IMAPSearchExpression::searchTo(String * value)
     return (IMAPSearchExpression *) expr->autorelease();
 }
 
-IMAPSearchExpression * IMAPSearchExpression::searchCC(String * value)
+IMAPSearchExpression * IMAPSearchExpression::searchCc(String * value)
 {
     IMAPSearchExpression * expr = new IMAPSearchExpression();
-    expr->mKind = IMAPSearchKindCC;
+    expr->mKind = IMAPSearchKindCc;
     MC_SAFE_REPLACE_COPY(String, expr->mValue, value);
     return (IMAPSearchExpression *) expr->autorelease();
 }
 
-IMAPSearchExpression * IMAPSearchExpression::searchBCC(String * value)
+IMAPSearchExpression * IMAPSearchExpression::searchBcc(String * value)
 {
     IMAPSearchExpression * expr = new IMAPSearchExpression();
-    expr->mKind = IMAPSearchKindBCC;
+    expr->mKind = IMAPSearchKindBcc;
     MC_SAFE_REPLACE_COPY(String, expr->mValue, value);
     return (IMAPSearchExpression *) expr->autorelease();
 }

--- a/src/core/imap/MCIMAPSearchExpression.h
+++ b/src/core/imap/MCIMAPSearchExpression.h
@@ -28,8 +28,8 @@ namespace mailcore {
         static IMAPSearchExpression * searchAll();
         static IMAPSearchExpression * searchFrom(String * value);
         static IMAPSearchExpression * searchTo(String *value);
-        static IMAPSearchExpression * searchCC(String *value);
-        static IMAPSearchExpression * searchBCC(String *value);
+        static IMAPSearchExpression * searchCc(String *value);
+        static IMAPSearchExpression * searchBcc(String *value);
         static IMAPSearchExpression * searchRecipient(String * value);
         static IMAPSearchExpression * searchSubject(String * value);
         static IMAPSearchExpression * searchContent(String * value);

--- a/src/core/imap/MCIMAPSession.cc
+++ b/src/core/imap/MCIMAPSession.cc
@@ -2563,14 +2563,14 @@ IndexSet * IMAPSession::search(String * folder, IMAPSearchKind kind, String * se
             expr = IMAPSearchExpression::searchTo(searchString);
             break;
         }
-        case IMAPSearchKindCC:
+        case IMAPSearchKindCc:
         {
-            expr = IMAPSearchExpression::searchCC(searchString);
+            expr = IMAPSearchExpression::searchCc(searchString);
             break;
         }
-        case IMAPSearchKindBCC:
+        case IMAPSearchKindBcc:
         {
-            expr = IMAPSearchExpression::searchBCC(searchString);
+            expr = IMAPSearchExpression::searchBcc(searchString);
             break;
         }
         case IMAPSearchKindRecipient:
@@ -2612,11 +2612,11 @@ static struct mailimap_search_key * searchKeyFromSearchExpression(IMAPSearchExpr
         {
             return mailimap_search_key_new_to(strdup(expression->value()->UTF8Characters()));
         }
-        case IMAPSearchKindCC:
+        case IMAPSearchKindCc:
         {
             return mailimap_search_key_new_cc(strdup(expression->value()->UTF8Characters()));
         }
-        case IMAPSearchKindBCC:
+        case IMAPSearchKindBcc:
         {
             return mailimap_search_key_new_bcc(strdup(expression->value()->UTF8Characters()));
         }

--- a/src/objc/abstract/MCOConstants.h
+++ b/src/objc/abstract/MCOConstants.h
@@ -168,9 +168,9 @@ typedef enum {
     /** Match to */
     MCOIMAPSearchKindTo,
     /** Match CC: */
-    MCOIMAPSearchKindCC,
+    MCOIMAPSearchKindCc,
     /** Match BCC: */
-    MCOIMAPSearchKindBCC,
+    MCOIMAPSearchKindBcc,
     /** Match recipient.*/
     MCOIMAPSearchKindRecipient,
     /** Match subject.*/

--- a/src/objc/imap/MCOIMAPSearchExpression.h
+++ b/src/objc/imap/MCOIMAPSearchExpression.h
@@ -59,18 +59,18 @@
  
  Example:
  
- MCOIMAPSearchExpression * expr = [MCOIMAPSearchExpression searchCC:@"ngan@etpan.org"]
+ MCOIMAPSearchExpression * expr = [MCOIMAPSearchExpression searchCc:@"ngan@etpan.org"]
  **/
-+ (MCOIMAPSearchExpression *) searchCC:(NSString *)value;
++ (MCOIMAPSearchExpression *) searchCc:(NSString *)value;
 
 /**
  Creates a search expression that matches on the bcc field of an email. Useful to check whether the mail is addressed to the receiver as bcc.
  
  Example:
  
- MCOIMAPSearchExpression * expr = [MCOIMAPSearchExpression searchBCC:@"ngan@etpan.org"]
+ MCOIMAPSearchExpression * expr = [MCOIMAPSearchExpression searchBcc:@"ngan@etpan.org"]
  **/
-+ (MCOIMAPSearchExpression *) searchBCC:(NSString *)value;
++ (MCOIMAPSearchExpression *) searchBcc:(NSString *)value;
 
 /*
  Creates a search expression that matches the subject of an email.

--- a/src/objc/imap/MCOIMAPSearchExpression.mm
+++ b/src/objc/imap/MCOIMAPSearchExpression.mm
@@ -72,14 +72,14 @@
     return MCO_TO_OBJC(mailcore::IMAPSearchExpression::searchTo([value mco_mcString]));
 }
 
-+ (MCOIMAPSearchExpression *) searchCC:(NSString *)value
++ (MCOIMAPSearchExpression *) searchCc:(NSString *)value
 {
-    return MCO_TO_OBJC(mailcore::IMAPSearchExpression::searchCC([value mco_mcString]));
+    return MCO_TO_OBJC(mailcore::IMAPSearchExpression::searchCc([value mco_mcString]));
 }
 
-+ (MCOIMAPSearchExpression *) searchBCC:(NSString *)value
++ (MCOIMAPSearchExpression *) searchBcc:(NSString *)value
 {
-    return MCO_TO_OBJC(mailcore::IMAPSearchExpression::searchBCC([value mco_mcString]));
+    return MCO_TO_OBJC(mailcore::IMAPSearchExpression::searchBcc([value mco_mcString]));
 }
 + (MCOIMAPSearchExpression *) searchRecipient:(NSString *)value
 {


### PR DESCRIPTION
Added separate searches for to, cc and bcc fields which can for example be useful if you want to filter whether someone is only addressed on the cc line. 
Furthermore, with the ability of searching by uids there is now the possibility to make a more efficient filter if you want to filter only on new messages since the last search by storing the highest uid and use this as starting point for the next search.
