### PR TITLE
Fixed month and year calculation by adding +1 for month and +1900 for ye...

### DIFF
--- a/src/core/imap/MCIMAPSession.cc
+++ b/src/core/imap/MCIMAPSession.cc
@@ -2657,37 +2657,37 @@ static struct mailimap_search_key * searchKeyFromSearchExpression(IMAPSearchExpr
         {
             time_t date = expression->date();
             tm * timeinfo = localtime(&date);
-            return mailimap_search_key_new_sentbefore(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon, timeinfo->tm_year));
+            return mailimap_search_key_new_sentbefore(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon+1, timeinfo->tm_year+1900));
         }
         case IMAPSearchKindOnDate:
         {
             time_t date = expression->date();
             tm * timeinfo = localtime(&date);
-            return mailimap_search_key_new_senton(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon, timeinfo->tm_year));
+            return mailimap_search_key_new_senton(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon+1, timeinfo->tm_year+1900));
         }
         case IMAPSearchKindSinceDate:
         {
             time_t date = expression->date();
             tm * timeinfo = localtime(&date);
-            return mailimap_search_key_new_sentsince(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon, timeinfo->tm_year));
+            return mailimap_search_key_new_sentsince(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon+1, timeinfo->tm_year+1900));
         }
         case IMAPSearchKindBeforeReceivedDate:
         {
             time_t date = expression->date();
             tm * timeinfo = localtime(&date);
-            return mailimap_search_key_new_before(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon, timeinfo->tm_year));
+            return mailimap_search_key_new_before(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon+1, timeinfo->tm_year+1900));
         }
         case IMAPSearchKindOnReceivedDate:
         {
             time_t date = expression->date();
             tm * timeinfo = localtime(&date);
-            return mailimap_search_key_new_on(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon, timeinfo->tm_year));
+            return mailimap_search_key_new_on(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon+1, timeinfo->tm_year+1900));
         }
         case IMAPSearchKindSinceReceivedDate:
         {
             time_t date = expression->date();
             tm * timeinfo = localtime(&date);
-            return mailimap_search_key_new_since(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon, timeinfo->tm_year));
+            return mailimap_search_key_new_since(mailimap_date_new(timeinfo->tm_mday, timeinfo->tm_mon+1, timeinfo->tm_year+1900));
         }
         case IMAPSearchKindGmailThreadID:
         {


### PR DESCRIPTION
...ar.

the tm structure has months starting with 0, while libetpan expects that January starts at 1
Furthermore, the year component is an integer starting from 1900 while libetpan expects a 4 digit year number
