### PR TITLE
Make sure that the "size" property is propagated into the Message Info object during fetch

### DIFF
--- a/src/core/pop/MCPOPSession.cc
+++ b/src/core/pop/MCPOPSession.cc
@@ -439,6 +439,7 @@ Array * POPSession::fetchMessages(ErrorCode * pError)
         
         POPMessageInfo * info = new POPMessageInfo();
         info->setUid(uid);
+        info->setSize(msg_info->msg_size);
         info->setIndex(msg_info->msg_index);
         result->addObject(info);
         info->release();


### PR DESCRIPTION
I noticed that UID and index were being stored in the object based on fetch results, but size was always left as 0.
