### PR TITLE
fixed MCOIMAPCapabilityOperation header guard macro

### DIFF
--- a/src/objc/imap/MCOIMAPCapabilityOperation.h
+++ b/src/objc/imap/MCOIMAPCapabilityOperation.h
@@ -8,7 +8,7 @@
 
 #ifndef __MAILCORE_MCOIMAPCAPABILITYOPERATION_H_
 
-#define __MAILCORE_MCOIMAPCAPBILITYOPERATION_H_
+#define __MAILCORE_MCOIMAPCAPABILITYOPERATION_H_
 
 /** 
  This class implements an operation to query for IMAP capabilities, 


### PR DESCRIPTION
The define after the ifndef is not the same as the one in the test.

Best
Marco
