### PR TITLE
Don't remove empty div elements.

### DIFF
--- a/src/core/basetypes/MCHTMLCleaner.cc
+++ b/src/core/basetypes/MCHTMLCleaner.cc
@@ -34,6 +34,7 @@ String * HTMLCleaner::cleanHTML(String * input)
     Data * data = input->dataUsingEncoding("utf-8");
     tidyBufAppend(&docbuf, data->bytes(), data->length());
     
+    tidyOptSetBool(tdoc, TidyDropEmptyElems, no);
     tidyOptSetBool(tdoc, TidyXhtmlOut, yes);
     tidySetCharEncoding(tdoc, "utf8");
     tidyOptSetBool(tdoc, TidyForceOutput, yes);


### PR DESCRIPTION
Tidy shouldn't be removing any empty dom elements like <div></div>.  Let the browser determine how it should be displayed.
