### PR TITLE
Update providers.json

### DIFF
--- a/resources/providers.json
+++ b/resources/providers.json
@@ -304,7 +304,7 @@
                 {
                     "port":587,
                     "hostname":"smtp.gmail.com",
-                    "starttls":true
+                    "ssl":true
                 },
                 {
                     "port":465,


### PR DESCRIPTION
Port 587 requires SSL.  Start TLS connections fail with:

Error sending email: Error Domain=MCOErrorDomain Code=5 "Unable to authenticate with the current session's credentials." UserInfo=0x1308c500 {NSLocalizedDescription=Unable to authenticate with the current session's credentials.}
