### PR TITLE
Turn off TidyMark to clean up HTML output

### DIFF
--- a/src/core/basetypes/MCHTMLCleaner.cc
+++ b/src/core/basetypes/MCHTMLCleaner.cc
@@ -43,6 +43,7 @@ String * HTMLCleaner::cleanHTML(String * input)
     tidyOptSetBool(tdoc, TidyDropEmptyElems, no);
 #endif
     tidyOptSetBool(tdoc, TidyXhtmlOut, yes);
+    tidyOptSetBool(tdoc, TidyMark, no);
     tidySetCharEncoding(tdoc, "utf8");
     tidyOptSetBool(tdoc, TidyForceOutput, yes);
     //tidyOptSetValue(tdoc, TidyErrFile, "/dev/null");


### PR DESCRIPTION
Turns off the TidyMark flag, which prevents Tidy from adding its signature to HTML it has touched.
