### PR TITLE
Support ‘domain-exclude’ in providers.json

### DIFF
--- a/resources/providers.json
+++ b/resources/providers.json
@@ -255,6 +255,34 @@
             "trash":"Trash"
         }
     },
+    "yahoo.co.jp":{
+        "servers":{
+            "imap":[
+                {
+                    "port":993,
+                    "hostname":"imap.mail.yahoo.co.jp",
+                    "ssl":true
+                }
+            ],
+            "smtp":[
+                {
+                    "port":465,
+                    "hostname":"smtp.mail.yahoo.co.jp",
+                    "ssl":true
+                }
+            ]
+        },
+        "domain-match":[
+            "yahoo\\.co\\.jp"
+        ],
+        "mailboxes":{
+            "drafts":"Draft",
+            "allmail":"Archive",
+            "spam":"Bulk Mail",
+            "sentmail":"Sent",
+            "trash":"Trash"
+        }
+    },
     "yahoo":{
         "servers":{
             "imap":[
@@ -287,6 +315,9 @@
             "ymail\\.com",
             "rocketmail\\.com",
             "xtra\\.co\\.nz"
+        ],
+        "domain-exclude":[
+            "yahoo\\.co\\.jp"
         ],
         "mailboxes":{
             "drafts":"Draft",

--- a/src/core/provider/MCMailProvider.cc
+++ b/src/core/provider/MCMailProvider.cc
@@ -22,6 +22,7 @@ void MailProvider::init()
     mSmtpServices = new Array();
     mPopServices = new Array();
     mDomainMatch = new Array();
+    mDomainExclude = new Array();
     mMxMatch = new Array();
     mMailboxPaths = NULL;
 }
@@ -39,6 +40,7 @@ MailProvider::MailProvider(MailProvider * other)
     MC_SAFE_REPLACE_COPY(Array, mSmtpServices, other->mSmtpServices);
     MC_SAFE_REPLACE_COPY(Array, mPopServices, other->mPopServices);
     MC_SAFE_REPLACE_COPY(Array, mDomainMatch, other->mDomainMatch);
+    MC_SAFE_REPLACE_COPY(Array, mDomainExclude, other->mDomainExclude);
     MC_SAFE_REPLACE_COPY(Array, mMxMatch, other->mMxMatch);
     MC_SAFE_REPLACE_COPY(HashMap, mMailboxPaths, other->mMailboxPaths);
 }
@@ -50,6 +52,7 @@ MailProvider::~MailProvider()
     MC_SAFE_RELEASE(mPopServices);
     MC_SAFE_RELEASE(mMxMatch);
     MC_SAFE_RELEASE(mDomainMatch);
+    MC_SAFE_RELEASE(mDomainExclude);
     MC_SAFE_RELEASE(mMailboxPaths);
     MC_SAFE_RELEASE(mIdentifier);
 }
@@ -72,6 +75,10 @@ void MailProvider::fillWithInfo(HashMap * info)
     MC_SAFE_RELEASE(mDomainMatch);
     if (info->objectForKey(MCSTR("domain-match")) != NULL) {
         mDomainMatch = (Array *) info->objectForKey(MCSTR("domain-match"))->retain();
+    }
+    MC_SAFE_RELEASE(mDomainExclude);
+    if (info->objectForKey(MCSTR("domain-exclude")) != NULL) {
+        mDomainExclude = (Array *) info->objectForKey(MCSTR("domain-exclude"))->retain();
     }
     MC_SAFE_RELEASE(mMailboxPaths);
     if (info->objectForKey(MCSTR("mailboxes")) != NULL) {
@@ -146,6 +153,12 @@ bool MailProvider::matchEmail(String * email)
     
     domain = (String *) components->lastObject();
 
+    mc_foreacharray(String, exclude, mDomainExclude) {
+        if (matchDomain(exclude, domain)){
+            return false;
+        }
+    }
+    
     mc_foreacharray(String, match, mDomainMatch) {
         if (matchDomain(match, domain)){
             return true;

--- a/src/core/provider/MCMailProvider.h
+++ b/src/core/provider/MCMailProvider.h
@@ -57,6 +57,7 @@ namespace mailcore {
     private:
         String * mIdentifier;
         Array * /* String */ mDomainMatch;
+        Array * /* String */ mDomainExclude;
         Array * /* String */ mMxMatch;
         Array * /* NetService */ mImapServices;
         Array * /* NetService */ mSmtpServices;


### PR DESCRIPTION
Added yahoo.co.jp as a separate provider, and excluded yahoo.co.jp from the main yahoo mail provider #709
