### PR TITLE
Fixed MCString::htmlMessageContent()

### DIFF
--- a/src/core/basetypes/MCString.cc
+++ b/src/core/basetypes/MCString.cc
@@ -2219,7 +2219,7 @@ String * String::htmlMessageContent()
     
     if (quoted != NULL) {
         localString->appendString(MCSTR("<blockquote type=\"cite\">"));
-        localString->appendString(quoted);
+        localString->appendString(quoted->htmlMessageContent());
         localString->appendString(MCSTR("</blockquote>"));
         MC_SAFE_RELEASE(quoted);
     }


### PR DESCRIPTION
The method didn't work with next content of text part:

```
Von meinem iPhone gesendet

> Am 27 May 2014 um 11:34 schrieb Viktor G <foxinushka@gmail.com>:
> 
> test
```
