### PR TITLE
Potential fix for crashes caused by NULL value returned when parsing text with japanese encoding

### DIFF
--- a/src/core/basetypes/MCData.cc
+++ b/src/core/basetypes/MCData.cc
@@ -283,6 +283,9 @@ String * Data::stringWithDetectedCharset(String * hintCharset, bool isHTML)
         if (result == NULL) {
             result = data->stringWithCharset("iso-2022-jp");
         }
+        if (result == NULL) {
+            result = MCSTR("");
+        }
         
         return result;
     }


### PR DESCRIPTION
This fixes #735 by making sure that the same check in place for non 'iso-2022-jp-2' charset to make sure that non-NULL value is returned in 

```
String * Data::stringWithDetectedCharset(String * hintCharset, bool isHTML)
```

is also put in place for 'iso-2022-jp-2'  charset. 

Non 'iso-2022-jp-2' charset already has the following checks in place

```
if (result == NULL) {
        result = stringWithCharset("iso-8859-1");
    }
    if (result == NULL) {
        result = stringWithCharset("windows-1252");
    }
    if (result == NULL) {
        result = stringWithCharset("utf-8");
    }
    if (result == NULL) {
        result = MCSTR("");
    }
```

But I've only included the last check. Let me know if that's sufficient. 
