### PR TITLE
Add support for iOS8 in the build scripts

### DIFF
--- a/scripts/build-mailcore2-ios.sh
+++ b/scripts/build-mailcore2-ios.sh
@@ -9,6 +9,9 @@ elif xcodebuild -showsdks|grep iphoneos7.0 >/dev/null ; then
 elif xcodebuild -showsdks|grep iphoneos7.1 >/dev/null ; then
   sdkversion=7.1
   devicearchs="armv7 armv7s arm64"
+elif xcodebuild -showsdks|grep iphoneos8.0 >/dev/null ; then
+  sdkversion=8.0
+  devicearchs="armv7 armv7s arm64"
 else
 	echo SDK not found
 	exit 1

--- a/scripts/prepare-ctemplate-ios.sh
+++ b/scripts/prepare-ctemplate-ios.sh
@@ -2,7 +2,10 @@
 
 url="https://github.com/dinhviethoa/ctemplate"
 
-if xcodebuild -showsdks|grep iphoneos7.1 >/dev/null ; then
+if xcodebuild -showsdks|grep iphoneos8.0 >/dev/null ; then
+	sdkversion=8.0
+    MARCHS="armv7 armv7s arm64"
+elif xcodebuild -showsdks|grep iphoneos7.1 >/dev/null ; then
 	sdkversion=7.1
     MARCHS="armv7 armv7s arm64"
 elif xcodebuild -showsdks|grep iphoneos7.0 >/dev/null ; then

--- a/scripts/prepare-icu4c-ios.sh
+++ b/scripts/prepare-icu4c-ios.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-if xcodebuild -showsdks|grep iphoneos7.1 >/dev/null ; then
+if xcodebuild -showsdks|grep iphoneos8.0 >/dev/null ; then
+	sdkversion=8.0
+    MARCHS="armv7 armv7s arm64"
+elif xcodebuild -showsdks|grep iphoneos7.1 >/dev/null ; then
     sdkversion=7.1
     archs="armv7 armv7s arm64 i386 x86_64"
 elif xcodebuild -showsdks|grep iphoneos7.0 >/dev/null ; then

--- a/scripts/prepare-libetpan-ios.sh
+++ b/scripts/prepare-libetpan-ios.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-if xcodebuild -showsdks|grep iphoneos7.1 >/dev/null ; then
+if xcodebuild -showsdks|grep iphoneos8.0 >/dev/null ; then
+	sdkversion=8.0
+    MARCHS="armv7 armv7s arm64"
+elif xcodebuild -showsdks|grep iphoneos7.1 >/dev/null ; then
 	sdkversion=7.1
     devicearchs="armv7 armv7s arm64"
 elif xcodebuild -showsdks|grep iphoneos7.0 >/dev/null ; then

--- a/scripts/prepare-tidy-ios.sh
+++ b/scripts/prepare-tidy-ios.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-if xcodebuild -showsdks|grep iphoneos7.1 >/dev/null ; then
+if xcodebuild -showsdks|grep iphoneos8.0 >/dev/null ; then
+	sdkversion=8.0
+    MARCHS="armv7 armv7s arm64"
+elif xcodebuild -showsdks|grep iphoneos7.1 >/dev/null ; then
 	sdkversion=7.1
     devicearchs="armv7 armv7s arm64"	 
 elif xcodebuild -showsdks|grep iphoneos7.0 >/dev/null ; then


### PR DESCRIPTION
When building MailCore for the first time with XCode6 and iOS8, the project fails to build, as a number of scripts fail with an "SDK Not Found" error.  This PR adds a check for iOS8 to the relevant scripts, which allows MailCore to build with no problems.
