### PR TITLE
dispatch_queue_t property: check OS_OBJECT_HAVE_OBJC_SUPPORT

### DIFF
--- a/src/objc/imap/MCOIMAPSession.h
+++ b/src/objc/imap/MCOIMAPSession.h
@@ -117,7 +117,11 @@
  It will make MCOIMAPSession safe. It will also set all the callbacks of operations to run on this given queue.
  Defaults to the main queue.
  This property should be used only if there's performance issue using MCOIMAPSession in the main thread. */
+#if OS_OBJECT_USE_OBJC
 @property (nonatomic, retain) dispatch_queue_t dispatchQueue;
+#else
+@property (nonatomic, assign) dispatch_queue_t dispatchQueue;
+#endif
 
 /**
  The value will be YES when asynchronous operations are running, else it will return NO.

--- a/src/objc/pop/MCOPOPSession.h
+++ b/src/objc/pop/MCOPOPSession.h
@@ -66,7 +66,11 @@ See MCOConnectionType for more information.*/
  It will make MCOPOPSession safe. It will also set all the callbacks of operations to run on this given queue.
  Defaults to the main queue.
  This property should be used only if there's performance issue using MCOPOPSession in the main thread. */
+#if OS_OBJECT_USE_OBJC
 @property (nonatomic, retain) dispatch_queue_t dispatchQueue;
+#else
+@property (nonatomic, assign) dispatch_queue_t dispatchQueue;
+#endif
 
 /** @name Operations */
 

--- a/src/objc/smtp/MCOSMTPSession.h
+++ b/src/objc/smtp/MCOSMTPSession.h
@@ -80,7 +80,11 @@
  It will make MCOSMTPSession safe. It will also set all the callbacks of operations to run on this given queue.
  Defaults to the main queue.
  This property should be used only if there's performance issue using MCOSMTPSession in the main thread. */
+#if OS_OBJECT_USE_OBJC
 @property (nonatomic, retain) dispatch_queue_t dispatchQueue;
+#else
+@property (nonatomic, assign) dispatch_queue_t dispatchQueue;
+#endif
 
 /** @name Operations */
 

--- a/src/objc/utils/MCOOperation.h
+++ b/src/objc/utils/MCOOperation.h
@@ -23,7 +23,11 @@
 /** The queue this operation dispatches the callback on.  Defaults to the main queue.
  This property should be used only if there's performance issue creating or calling the callback
  in the main thread. */
+#if OS_OBJECT_USE_OBJC
 @property (nonatomic, retain) dispatch_queue_t callbackDispatchQueue;
+#else
+@property (nonatomic, assign) dispatch_queue_t callbackDispatchQueue;
+#endif
 
 /** This methods is called on the main thread when the asynchronous operation is finished.
  Needs to be overriden by subclasses.*/


### PR DESCRIPTION
Fixed compile error "Property with retain (or strong) attribute must be object type" (iOS < 6).

![screenshot](https://dl.dropboxusercontent.com/u/25357310/dispatch_queue_t.png)
