### PR TITLE
Fixed addressWithIMAPAddress for drafts with bad address in to/cc/bcc fields

### DIFF
--- a/src/core/abstract/MCAddress.cc
+++ b/src/core/abstract/MCAddress.cc
@@ -84,7 +84,7 @@ Address * Address::addressWithIMAPAddress(struct mailimap_address * imap_addr)
         else {
             addr = imap_addr->ad_mailbox_name;
         }
-        mailbox = String::stringWithUTF8Characters(addr);
+        mailbox = String::stringByDecodingMIMEHeaderValue(addr);
         if (mailbox == NULL) {
             mailbox = MCSTR("");
         }


### PR DESCRIPTION
Google allows to save drafts with display name in fields to/cc/bcc instead mailbox value.
In this case if display name contains non-english characters we should to decode them.
