### PR TITLE
use NS_ENUM and NS_OPTIONS

### DIFF
--- a/src/objc/abstract/MCOAbstractPart.h
+++ b/src/objc/abstract/MCOAbstractPart.h
@@ -14,7 +14,7 @@
 
 @class MCOAbstractMessage;
 
-typedef enum {
+typedef NS_ENUM(NSInteger, MCOPartType) {
     // Used for a single part.
     // The part will be a MCOAbstractPart.
     MCOPartTypeSingle,
@@ -35,7 +35,7 @@ typedef enum {
     // Used for a multipart, multipart/alternative.
     // The part will be a MCOAbstractMultipart.
     MCOPartTypeMultipartAlternative,
-} MCOPartType;
+};
 
 @interface MCOAbstractPart : NSObject <NSCopying>
 

--- a/src/objc/abstract/MCOConstants.h
+++ b/src/objc/abstract/MCOConstants.h
@@ -3,7 +3,7 @@
 #define MAILCORE_MCOCONSTANTS_H
 
 /** It's the connection type.*/
-typedef enum {
+typedef NS_OPTIONS(NSInteger, MCOConnectionType) {
     /** Clear-text connection for the protocol.*/
     MCOConnectionTypeClear             = 1 << 0,
     /** Clear-text connection at the beginning, then switch to encrypted connection using TLS/SSL*/
@@ -11,10 +11,10 @@ typedef enum {
     MCOConnectionTypeStartTLS          = 1 << 1,
     /** Encrypted connection using TLS/SSL.*/
     MCOConnectionTypeTLS               = 1 << 2,
-} MCOConnectionType;
+};
 
 /** It's the authentication type.*/
-typedef enum {
+typedef NS_OPTIONS(NSInteger, MCOAuthType) {
     /** Default authentication scheme of the protocol.*/
     MCOAuthTypeSASLNone          = 0,
     /** CRAM-MD5 authentication RFC 2195.*/
@@ -37,10 +37,10 @@ typedef enum {
     MCOAuthTypeXOAuth2           = 1 << 8,
     /** OAuth2 authentication on outlook.com.*/
     MCOAuthTypeXOAuth2Outlook    = 1 << 9,
-} MCOAuthType;
+};
 
 /** It's the IMAP flags of the folder.*/
-typedef enum {
+typedef NS_OPTIONS(NSInteger, MCOIMAPFolderFlag) {
     MCOIMAPFolderFlagNone        = 0,
     /** \Marked*/
     MCOIMAPFolderFlagMarked      = 1 << 0,
@@ -77,10 +77,10 @@ typedef enum {
     /** Mask to identify the folder */
     MCOIMAPFolderFlagFolderTypeMask = MCOIMAPFolderFlagInbox | MCOIMAPFolderFlagSentMail | MCOIMAPFolderFlagStarred | MCOIMAPFolderFlagAllMail |
       MCOIMAPFolderFlagTrash| MCOIMAPFolderFlagDrafts | MCOIMAPFolderFlagSpam | MCOIMAPFolderFlagImportant | MCOIMAPFolderFlagArchive,
-} MCOIMAPFolderFlag;
+};
 
 /** It's the flags of a message.*/
-typedef enum {
+typedef NS_OPTIONS(NSInteger, MCOMessageFlag) {
     MCOMessageFlagNone          = 0,
     /** Seen/Read flag.*/
     MCOMessageFlagSeen          = 1 << 0,
@@ -100,10 +100,10 @@ typedef enum {
     MCOMessageFlagSubmitPending = 1 << 7,
     /** $Submitted flag.*/
     MCOMessageFlagSubmitted     = 1 << 8,
-} MCOMessageFlag;
+};
 
 /** It's the encoding of a part.*/
-typedef enum {
+typedef NS_ENUM(NSInteger, MCOEncoding) {
     /** 7bit encoding.*/
     MCOEncoding7Bit = 0,            /** should match MAILIMAP_BODY_FLD_ENC_7BIT*/
     /** 8bit encoding.*/
@@ -121,10 +121,10 @@ typedef enum {
     
     /** UUEncode encoding.*/
     MCOEncodingUUEncode = -1
-} MCOEncoding;
+};
 
 /** It's the information to fetch for a given message in the IMAP FETCH request.*/
-typedef enum {
+typedef NS_OPTIONS(NSInteger, MCOIMAPMessagesRequestKind) {
     /** UID of the message.*/
     MCOIMAPMessagesRequestKindUid            = 0, /** This is the default and it's always fetched*/
     /** Flags of the message.*/
@@ -150,20 +150,20 @@ typedef enum {
     /* Request size of message */
     MCOIMAPMessagesRequestKindSize           = 1 << 10,
 
-} MCOIMAPMessagesRequestKind;
+};
 
 /** It defines the behavior of the STORE flags request.*/
-typedef enum {
+typedef NS_ENUM(NSInteger, MCOIMAPStoreFlagsRequestKind) {
     /** Add the given flags.*/
     MCOIMAPStoreFlagsRequestKindAdd,
     /** Remove the given flags.*/
     MCOIMAPStoreFlagsRequestKindRemove,
     /** Set the given flags.*/
     MCOIMAPStoreFlagsRequestKindSet,
-} MCOIMAPStoreFlagsRequestKind;
+};
 
 /** It's the search type.*/
-typedef enum {
+typedef NS_ENUM(NSInteger, MCOIMAPSearchKind) {
     /** Search All */
     MCOIMAPSearchKindAll,
     /** No search.*/
@@ -234,7 +234,7 @@ typedef enum {
     MCOIMAPSearchKindAnd,
     /** Not expression.*/
     MCOIMAPSearchKindNot,
-} MCOIMAPSearchKind;
+};
 
 /** Keys for the namespace dictionary.*/
 #define MCOIMAPNamespacePersonal @"IMAPNamespacePersonal"
@@ -243,7 +243,7 @@ typedef enum {
 
 /** This is the constants for the IMAP capabilities.*/
 /** See corresponding RFC for more information.*/
-typedef enum {
+typedef NS_ENUM(NSInteger, MCOIMAPCapability) {
     /** ACL Capability.*/
     MCOIMAPCapabilityACL,
     /** BINARY Capability.*/
@@ -314,13 +314,13 @@ typedef enum {
     MCOIMAPCapabilityXOAuth2,
     /** X-GM-EXT-1 Capability.*/
     MCOIMAPCapabilityGmail
-} MCOIMAPCapability;
+};
 
 /** Error domain for mailcore.*/
 #define MCOErrorDomain @"MCOErrorDomain"
 
 /** Here's the list of errors.*/
-typedef enum {
+typedef NS_ENUM(NSInteger, MCOErrorCode) {
     /** No error occurred.*/
     MCOErrorNone,
     /** An error related to the connection occurred.*/
@@ -402,10 +402,10 @@ typedef enum {
     MCOErrorNoop,
     /** The count of all errors */
     MCOErrorCodeCount,
-} MCOErrorCode;
+};
 
 /** Here's the list of connection log types.*/
-typedef enum {
+typedef NS_ENUM(NSInteger, MCOConnectionLogType) {
     /** Received data.*/
     MCOConnectionLogTypeReceived,
     /** Sent data.*/
@@ -418,7 +418,7 @@ typedef enum {
     MCOConnectionLogTypeErrorReceived,
     /** Error while sending dataThe data passed to the log will be nil.*/
     MCOConnectionLogTypeErrorSent,
-} MCOConnectionLogType;
+};
 
 /**
  It's a network traffic logger.


### PR DESCRIPTION
Using these macros brings a couple benefits with no drawbacks
- establish a fixed type (I used NSInteger) for enums
- add hints to compiler and IDE for auto-complete, switch statement exhaustiveness, and LLDB printing value names
- allow Swift compiler to auto-generate RawOptionSet / Swift enums
