### PR TITLE
Crash fix if htmlForAbstract part returns NULL

### DIFF
--- a/src/core/renderer/MCHTMLRenderer.cc
+++ b/src/core/renderer/MCHTMLRenderer.cc
@@ -415,7 +415,11 @@ String * htmlForAbstractMultipartAlternative(AbstractMultipart * part, htmlRende
     }
 
     String * result = String::string();
-    result->appendString(htmlForAbstractPart(preferredAlternative, context));
+    String * abstractPart = htmlForAbstractPart(preferredAlternative, context);
+    
+    if(abstractPart != NULL) {
+        result->appendString(abstractPart);
+    }
     if (calendar != NULL) {
         result->appendString(htmlForAbstractPart(calendar, context));
     }


### PR DESCRIPTION
I have a message where htmlForAbstract part is null and then inside the appendString it will crash.
