### PR TITLE
Fixed thread safety in OperationQueue

### DIFF
--- a/src/core/basetypes/MCOperationQueue.cc
+++ b/src/core/basetypes/MCOperationQueue.cc
@@ -178,11 +178,21 @@ void OperationQueue::checkRunningOnMainThread(void * context)
 {
     retain(); // (4)
     if (_pendingCheckRunning) {
+#if __APPLE__
+        cancelDelayedPerformMethodOnDispatchQueue((Object::Method) &OperationQueue::checkRunningAfterDelay, NULL, mDispatchQueue);
+#else
         cancelDelayedPerformMethod((Object::Method) &OperationQueue::checkRunningAfterDelay, NULL);
+#endif
         release(); // (4)
     }
     _pendingCheckRunning = true;
+    
+#if __APPLE__
+    performMethodOnDispatchQueueAfterDelay((Object::Method) &OperationQueue::checkRunningAfterDelay, NULL, mDispatchQueue, 1);
+#else
     performMethodAfterDelay((Object::Method) &OperationQueue::checkRunningAfterDelay, NULL, 1);
+#endif
+
     release(); // (1)
 }
 


### PR DESCRIPTION
checkRunningOnMainThread is executed on mDispatchQueue.
checkRunningAfterDelay was executed on main dispatch queue.

So, It was possible a situation when checkRunningAfterDelay is started, but not reached line _pendingCheckRunning = false;
and checkRunningOnMainThread reached line
release(); // (4) 

So, in this case it makes extra release().
