### PR TITLE
Only prepare pre-requisites for the current SDK/platform

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,4 +1,15 @@
 #!/bin/sh
 
-./prepare-mac.sh
-./prepare-ios.sh
+# If this script is run outside of Xcode, prepare both platforms by default
+if [ -z "$SDKROOT" ]; then
+    SDKROOT="MacOSX iPhone"
+fi
+
+if echo "$SDKROOT" | grep -q "MacOSX"; then
+    echo "Preparing Mac"
+    ./prepare-mac.sh
+fi
+if echo "$SDKROOT" | grep -q "iPhone"; then
+    echo "Preparing iOS"
+    ./prepare-ios.sh
+fi


### PR DESCRIPTION
If you do not have one of the platforms (iPhone or MacOSX) installed, the prepare.sh script stage of the build fails. Also, if you are only building for Mac _or_ iPhone, it makes sense to only build the pre-requisites for a single platform.

Note, you'll have to squash my three commits, because I had to revert the first attempt, when I accidentally included a change I didn't want to.
