### PR TITLE
Add an operation to fetch a parsed message.

### DIFF
--- a/build-mac/mailcore2.xcodeproj/project.pbxproj
+++ b/build-mac/mailcore2.xcodeproj/project.pbxproj
@@ -524,6 +524,16 @@
 		4B3C1BE517AC0176008BBF4C /* MCIMAPQuotaOperation.cc in Sources */ = {isa = PBXBuildFile; fileRef = 4B3C1BDF17ABF4BB008BBF4C /* MCIMAPQuotaOperation.cc */; };
 		4BE4029117B548B900ECC5E4 /* MCOIMAPQuotaOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4B3C1BDC17ABF306008BBF4C /* MCOIMAPQuotaOperation.h */; };
 		4BE4029217B548D900ECC5E4 /* MCIMAPQuotaOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4B3C1BE017ABF4BC008BBF4C /* MCIMAPQuotaOperation.h */; };
+		8199FBE919FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8199FBE719FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8199FBEA19FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8199FBE719FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8199FBEB19FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8199FBE819FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.mm */; };
+		8199FBEC19FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8199FBE819FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.mm */; };
+		8199FBF119FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8199FBEF19FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.cc */; };
+		8199FBF219FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.cc in Sources */ = {isa = PBXBuildFile; fileRef = 8199FBEF19FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.cc */; };
+		8199FBF519FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8199FBF019FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		8199FBF619FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8199FBF019FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8199FBF719FAF3AF0040BBC3 /* MCOIMAPFetchParsedContentOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8199FBE719FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.h */; };
+		8199FBF819FAF3AF0040BBC3 /* MCIMAPFetchParsedContentOperation.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8199FBF019FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.h */; };
 		8416A99D17F284F400B3C7DA /* MCOSMTPNoopOperation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8416A99C17F284F400B3C7DA /* MCOSMTPNoopOperation.mm */; };
 		8416A99E17F284F400B3C7DA /* MCOSMTPNoopOperation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8416A99C17F284F400B3C7DA /* MCOSMTPNoopOperation.mm */; };
 		8416A9A117F2871D00B3C7DA /* MCOIMAPNoopOperation.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8416A9A017F2871D00B3C7DA /* MCOIMAPNoopOperation.mm */; };
@@ -1638,6 +1648,8 @@
 			dstPath = include/MailCore;
 			dstSubfolderSpec = 16;
 			files = (
+				8199FBF719FAF3AF0040BBC3 /* MCOIMAPFetchParsedContentOperation.h in CopyFiles */,
+				8199FBF819FAF3AF0040BBC3 /* MCIMAPFetchParsedContentOperation.h in CopyFiles */,
 				C6D4FD3619FA9F4F001F7E01 /* MCNNTPFetchServerTimeOperation.h in CopyFiles */,
 				C6D4FD3519FA9F4D001F7E01 /* MCONNTPFetchServerTimeOperation.h in CopyFiles */,
 				C6D4FD3319FA9EB3001F7E01 /* MCONNTPFetchOverviewOperation.h in CopyFiles */,
@@ -1858,6 +1870,10 @@
 		4B3C1BDD17ABF307008BBF4C /* MCOIMAPQuotaOperation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MCOIMAPQuotaOperation.mm; sourceTree = "<group>"; };
 		4B3C1BDF17ABF4BB008BBF4C /* MCIMAPQuotaOperation.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MCIMAPQuotaOperation.cc; sourceTree = "<group>"; };
 		4B3C1BE017ABF4BC008BBF4C /* MCIMAPQuotaOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCIMAPQuotaOperation.h; sourceTree = "<group>"; };
+		8199FBE719FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCOIMAPFetchParsedContentOperation.h; sourceTree = "<group>"; };
+		8199FBE819FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MCOIMAPFetchParsedContentOperation.mm; sourceTree = "<group>"; };
+		8199FBEF19FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MCIMAPFetchParsedContentOperation.cc; sourceTree = "<group>"; };
+		8199FBF019FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCIMAPFetchParsedContentOperation.h; sourceTree = "<group>"; };
 		8416A99B17F284F400B3C7DA /* MCOSMTPNoopOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCOSMTPNoopOperation.h; sourceTree = "<group>"; };
 		8416A99C17F284F400B3C7DA /* MCOSMTPNoopOperation.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MCOSMTPNoopOperation.mm; sourceTree = "<group>"; };
 		8416A99F17F2871D00B3C7DA /* MCOIMAPNoopOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MCOIMAPNoopOperation.h; sourceTree = "<group>"; };
@@ -2670,6 +2686,8 @@
 				C64EA81916A29ADB00778456 /* MCIMAPFetchMessagesOperation.h */,
 				C64EA81B16A29DC100778456 /* MCIMAPFetchContentOperation.cc */,
 				C64EA81C16A29DC400778456 /* MCIMAPFetchContentOperation.h */,
+				8199FBEF19FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.cc */,
+				8199FBF019FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.h */,
 				C64EA81E16A29E3D00778456 /* MCIMAPStoreFlagsOperation.cc */,
 				C64EA81F16A29E3F00778456 /* MCIMAPStoreFlagsOperation.h */,
 				C64EA82116A29E4F00778456 /* MCIMAPStoreLabelsOperation.cc */,
@@ -3177,6 +3195,8 @@
 				C6F61F8317016A200073032E /* MCOIMAPFetchMessagesOperation.mm */,
 				C6F61F8517016AD60073032E /* MCOIMAPFetchContentOperation.h */,
 				C6F61F8617016AD60073032E /* MCOIMAPFetchContentOperation.mm */,
+				8199FBE719FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.h */,
+				8199FBE819FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.mm */,
 				C6F61F8817016AE60073032E /* MCOIMAPSearchOperation.h */,
 				C6F61F8917016AE60073032E /* MCOIMAPSearchOperation.mm */,
 				C6F61F8B17016AFA0073032E /* MCOIMAPIdleOperation.h */,
@@ -3219,6 +3239,7 @@
 				27780E4519CFA3F500C77E44 /* MCONNTPOperation+Private.h in Headers */,
 				27780E4E19CFA3F500C77E44 /* MCOAbstractMessage+Private.h in Headers */,
 				27780E5219CFA3F600C77E44 /* MCOAbstractPart+Private.h in Headers */,
+				8199FBF519FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.h in Headers */,
 				27780E5419CFA3F600C77E44 /* MCOAddress+Private.h in Headers */,
 				27780F2419CFA52800C77E44 /* MCOAttachment.h in Headers */,
 				27780F2519CFA52800C77E44 /* MCOMessageBuilder.h in Headers */,
@@ -3390,6 +3411,7 @@
 				27780ED519CFA40500C77E44 /* MCAbstractMultipart.h in Headers */,
 				27780ED619CFA40600C77E44 /* MCAbstractPart.h in Headers */,
 				27780ED719CFA40600C77E44 /* MCAddress.h in Headers */,
+				8199FBE919FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.h in Headers */,
 				27780ED819CFA40600C77E44 /* MCMessageConstants.h in Headers */,
 				27780ED919CFA40600C77E44 /* MCMessageHeader.h in Headers */,
 				27780EDA19CFA40600C77E44 /* MCArray.h in Headers */,
@@ -3482,6 +3504,7 @@
 				27780E2C19CFA39900C77E44 /* MCSMTPSendWithDataOperation.h in Headers */,
 				27780E2D19CFA39900C77E44 /* MCSMTPDisconnectOperation.h in Headers */,
 				27780E2E19CFA39900C77E44 /* MCSMTPNoopOperation.h in Headers */,
+				8199FBF619FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.h in Headers */,
 				27780E2F19CFA39900C77E44 /* MCSMTPOperation.h in Headers */,
 				27780E3019CFA39900C77E44 /* MCSMTPOperationCallback.h in Headers */,
 				27780E3119CFA39900C77E44 /* MCSMTPCheckAccountOperation.h in Headers */,
@@ -3653,6 +3676,7 @@
 				27780DE119CFA33B00C77E44 /* MCConnectionLogger.h in Headers */,
 				27780DE219CFA33B00C77E44 /* MCConnectionLoggerUtils.h in Headers */,
 				27780DE319CFA33B00C77E44 /* MCData.h in Headers */,
+				8199FBEA19FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.h in Headers */,
 				27780DE419CFA33C00C77E44 /* MCHash.h in Headers */,
 				27780DE519CFA33C00C77E44 /* MCHashMap.h in Headers */,
 				27780DE619CFA33C00C77E44 /* MCHTMLCleaner.h in Headers */,
@@ -4038,6 +4062,7 @@
 				C6E665B51796500B0063F2CF /* MCZip.cc in Sources */,
 				84B639E317F279BB003B5BA2 /* MCSMTPNoopOperation.cc in Sources */,
 				84CFA98319F7153B00FE35D2 /* MCONNTPFetchOverviewOperation.mm in Sources */,
+				8199FBEB19FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.mm in Sources */,
 				C64EA706169E847800778456 /* MCAssert.c in Sources */,
 				84D73793199C0511005124E5 /* MCONNTPGroupInfo.mm in Sources */,
 				C64EA708169E847800778456 /* MCData.cc in Sources */,
@@ -4130,6 +4155,7 @@
 				F87F190C16BB62B00012652F /* MCOIMAPFetchFoldersOperation.mm in Sources */,
 				84B639F117F282B4003B5BA2 /* MCOPOPNoopOperation.mm in Sources */,
 				C6EB30F716B8C9480091F4F1 /* NSDictionary+MCO.mm in Sources */,
+				8199FBF119FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.cc in Sources */,
 				C6EB30FE16B8E50F0091F4F1 /* NSArray+MCO.mm in Sources */,
 				C6EB310116B8E6E60091F4F1 /* NSObject+MCO.mm in Sources */,
 				C63CD67F16BDCDD400DB18F1 /* MCAddressDisplay.cc in Sources */,
@@ -4274,6 +4300,7 @@
 				C6E665B61796500B0063F2CF /* MCZip.cc in Sources */,
 				84B639E417F279BB003B5BA2 /* MCSMTPNoopOperation.cc in Sources */,
 				84CFA98419F7153B00FE35D2 /* MCONNTPFetchOverviewOperation.mm in Sources */,
+				8199FBEC19FAEA440040BBC3 /* MCOIMAPFetchParsedContentOperation.mm in Sources */,
 				C6BA2BA11705F4E6003F0E9E /* MCAssert.c in Sources */,
 				84D73794199C0511005124E5 /* MCONNTPGroupInfo.mm in Sources */,
 				C6BA2BA21705F4E6003F0E9E /* MCData.cc in Sources */,
@@ -4366,6 +4393,7 @@
 				C6BA2BE21705F4E6003F0E9E /* NSError+MCO.mm in Sources */,
 				C6BA2BE31705F4E6003F0E9E /* MCOIMAPFetchFoldersOperation.mm in Sources */,
 				84B639F217F282B4003B5BA2 /* MCOPOPNoopOperation.mm in Sources */,
+				8199FBF219FAF1270040BBC3 /* MCIMAPFetchParsedContentOperation.cc in Sources */,
 				C6BA2BE41705F4E6003F0E9E /* NSDictionary+MCO.mm in Sources */,
 				C6BA2BE51705F4E6003F0E9E /* NSArray+MCO.mm in Sources */,
 				C6BA2BE61705F4E6003F0E9E /* NSObject+MCO.mm in Sources */,

--- a/src/async/imap/MCAsyncIMAP.h
+++ b/src/async/imap/MCAsyncIMAP.h
@@ -17,6 +17,7 @@
 #include <MailCore/MCIMAPCopyMessagesOperation.h>
 #include <MailCore/MCIMAPFetchMessagesOperation.h>
 #include <MailCore/MCIMAPFetchContentOperation.h>
+#include <MailCore/MCIMAPFetchParsedContentOperation.h>
 #include <MailCore/MCIMAPIdleOperation.h>
 #include <MailCore/MCIMAPFolderInfoOperation.h>
 #include <MailCore/MCIMAPFolderStatusOperation.h>

--- a/src/async/imap/MCIMAPAsyncConnection.h
+++ b/src/async/imap/MCIMAPAsyncConnection.h
@@ -15,6 +15,7 @@ namespace mailcore {
     class IMAPCopyMessagesOperation;
     class IMAPFetchMessagesOperation;
     class IMAPFetchContentOperation;
+    class IMAPFetchParsedContentOperation;
     class IMAPIdleOperation;
     class IMAPFolderInfoOperation;
     class IMAPFolderStatusOperation;

--- a/src/async/imap/MCIMAPAsyncSession.cc
+++ b/src/async/imap/MCIMAPAsyncSession.cc
@@ -28,7 +28,7 @@
 #include "MCIMAPCopyMessagesOperation.h"
 #include "MCIMAPFetchMessagesOperation.h"
 #include "MCIMAPFetchContentOperation.h"
-#include "MCIMAPFetchContentOperation.h"
+#include "MCIMAPFetchParsedContentOperation.h"
 #include "MCIMAPStoreFlagsOperation.h"
 #include "MCIMAPStoreLabelsOperation.h"
 #include "MCIMAPSearchOperation.h"
@@ -52,7 +52,7 @@ IMAPAsyncSession::IMAPAsyncSession()
     mSessions = new Array();
     mMaximumConnections = DEFAULT_MAX_CONNECTIONS;
     mAllowsFolderConcurrentAccessEnabled = true;
-    
+
     mHostname = NULL;
     mPort = 0;
     mUsername = NULL;
@@ -244,7 +244,7 @@ IMAPAsyncConnection * IMAPAsyncSession::session()
     session->setConnectionLogger(mConnectionLogger);
     session->setOwner(this);
     session->autorelease();
-    
+
     session->setHostname(mHostname);
     session->setPort(mPort);
     session->setUsername(mUsername);
@@ -265,7 +265,7 @@ IMAPAsyncConnection * IMAPAsyncSession::session()
         session->setAutomaticConfigurationEnabled(false);
     }
 #endif
-    
+
     return session;
 }
 
@@ -283,7 +283,7 @@ IMAPAsyncConnection * IMAPAsyncSession::sessionForFolder(String * folder, bool u
                 return s;
             }
         }
-        
+
         s = matchingSessionForFolder(folder);
         s->setLastFolder(folder);
         return s;
@@ -544,6 +544,28 @@ IMAPFetchContentOperation * IMAPAsyncSession::fetchMessageAttachmentByNumberOper
     op->setNumber(number);
     op->setPartID(partID);
     op->setEncoding(encoding);
+    op->setUrgent(urgent);
+    op->autorelease();
+    return op;
+}
+
+IMAPFetchParsedContentOperation * IMAPAsyncSession::fetchParsedMessageByUIDOperation(String * folder, uint32_t uid, bool urgent)
+{
+    IMAPFetchParsedContentOperation * op = new IMAPFetchParsedContentOperation();
+    op->setMainSession(this);
+    op->setFolder(folder);
+    op->setUid(uid);
+    op->setUrgent(urgent);
+    op->autorelease();
+    return op;
+}
+
+IMAPFetchParsedContentOperation * IMAPAsyncSession::fetchParsedMessageByNumberOperation(String * folder, uint32_t number, bool urgent)
+{
+    IMAPFetchParsedContentOperation * op = new IMAPFetchParsedContentOperation();
+    op->setMainSession(this);
+    op->setFolder(folder);
+    op->setNumber(number);
     op->setUrgent(urgent);
     op->autorelease();
     return op;

--- a/src/async/imap/MCIMAPAsyncSession.h
+++ b/src/async/imap/MCIMAPAsyncSession.h
@@ -23,6 +23,7 @@ namespace mailcore {
     class IMAPCopyMessagesOperation;
     class IMAPFetchMessagesOperation;
     class IMAPFetchContentOperation;
+    class IMAPFetchParsedContentOperation;
     class IMAPIdleOperation;
     class IMAPFolderInfoOperation;
     class IMAPFolderStatusOperation;
@@ -137,6 +138,9 @@ namespace mailcore {
         virtual IMAPFetchContentOperation * fetchMessageAttachmentByNumberOperation(String * folder, uint32_t number, String * partID,
                                                                                     Encoding encoding, bool urgent = false);
         
+        virtual IMAPFetchParsedContentOperation * fetchParsedMessageByUIDOperation(String * folder, uint32_t uid, bool urgent = false);
+        virtual IMAPFetchParsedContentOperation * fetchParsedMessageByNumberOperation(String * folder, uint32_t number, bool urgent = false);
+
         virtual IMAPOperation * storeFlagsByUIDOperation(String * folder, IndexSet * uids, IMAPStoreFlagsRequestKind kind, MessageFlag flags, Array * customFlags = NULL);
         virtual IMAPOperation * storeFlagsByNumberOperation(String * folder, IndexSet * numbers, IMAPStoreFlagsRequestKind kind, MessageFlag flags, Array * customFlags = NULL);
         virtual IMAPOperation * storeLabelsByUIDOperation(String * folder, IndexSet * uids, IMAPStoreFlagsRequestKind kind, Array * labels);

--- a/src/async/imap/MCIMAPFetchParsedContentOperation.cc
+++ b/src/async/imap/MCIMAPFetchParsedContentOperation.cc
@@ -1,0 +1,79 @@
+//
+//  IMAPFetchParsedContentOperation.cc
+//  mailcore2
+//
+//  Created by DINH Viêt Hoà on 1/12/13.
+//  Copyright (c) 2013 MailCore. All rights reserved.
+//
+
+#include "MCIMAPFetchParsedContentOperation.h"
+
+#include "MCIMAPSession.h"
+#include "MCIMAPAsyncConnection.h"
+
+using namespace mailcore;
+
+IMAPFetchParsedContentOperation::IMAPFetchParsedContentOperation()
+{
+    mUid = 0;
+    mNumber = 0;
+    mEncoding = Encoding7Bit;
+    mParser = NULL;
+}
+
+IMAPFetchParsedContentOperation::~IMAPFetchParsedContentOperation()
+{
+    MC_SAFE_RELEASE(mParser);
+}
+
+void IMAPFetchParsedContentOperation::setUid(uint32_t uid)
+{
+    mUid = uid;
+}
+
+uint32_t IMAPFetchParsedContentOperation::uid()
+{
+    return mUid;
+}
+
+void IMAPFetchParsedContentOperation::setNumber(uint32_t value)
+{
+    mNumber = value;
+}
+
+uint32_t IMAPFetchParsedContentOperation::number()
+{
+    return mNumber;
+}
+
+void IMAPFetchParsedContentOperation::setEncoding(Encoding encoding)
+{
+    mEncoding = encoding;
+}
+
+Encoding IMAPFetchParsedContentOperation::encoding()
+{
+    return mEncoding;
+}
+
+MessageParser * IMAPFetchParsedContentOperation::parser()
+{
+    return mParser;
+}
+
+void IMAPFetchParsedContentOperation::main()
+{
+    ErrorCode error;
+    Data * data;
+    if (mUid != 0) {
+        data = session()->session()->fetchMessageByUID(folder(), mUid, this, &error);
+    }
+    else {
+        data = session()->session()->fetchMessageByNumber(folder(), mNumber, this, &error);
+    }
+    if (data) {
+        mParser = new mailcore::MessageParser(data);
+    }
+    setError(error);
+}
+

--- a/src/async/imap/MCIMAPFetchParsedContentOperation.h
+++ b/src/async/imap/MCIMAPFetchParsedContentOperation.h
@@ -1,0 +1,53 @@
+//
+//  IMAPFetchParsedContentOperation.h
+//  mailcore2
+//
+//  Created by DINH Viêt Hoà on 1/12/13.
+//  Copyright (c) 2013 MailCore. All rights reserved.
+//
+
+#ifndef MAILCORE_IMAPFETCHPARSEDCONTENTOPERATION_H
+
+#define MAILCORE_IMAPFETCHPARSEDCONTENTOPERATION_H
+
+#include <MailCore/MCIMAPOperation.h>
+
+#include <MailCore/MCRFC822.h>
+
+#ifdef __cplusplus
+
+namespace mailcore {
+
+    class IMAPFetchParsedContentOperation : public IMAPOperation {
+    public:
+        IMAPFetchParsedContentOperation();
+        virtual ~IMAPFetchParsedContentOperation();
+        
+        virtual void setUid(uint32_t uid);
+        virtual uint32_t uid();
+        
+        virtual void setNumber(uint32_t value);
+        virtual uint32_t number();
+        
+        virtual void setEncoding(Encoding encoding);
+        virtual Encoding encoding();
+        
+        // Result.
+        virtual MessageParser * parser();
+        
+    public: // subclass behavior
+        virtual void main();
+        
+    private:
+        uint32_t mUid;
+        uint32_t mNumber;
+        Encoding mEncoding;
+        MessageParser * mParser;
+        
+    };
+    
+}
+
+#endif
+
+#endif

--- a/src/cmake/async.cmake
+++ b/src/cmake/async.cmake
@@ -13,6 +13,7 @@ set(async_imap_files
   async/imap/MCIMAPDisconnectOperation.cc
   async/imap/MCIMAPExpungeOperation.cc
   async/imap/MCIMAPFetchContentOperation.cc
+  async/imap/MCIMAPFetchParsedContentOperation.cc
   async/imap/MCIMAPFetchFoldersOperation.cc
   async/imap/MCIMAPFetchMessagesOperation.cc
   async/imap/MCIMAPFetchNamespaceOperation.cc

--- a/src/cmake/objc.cmake
+++ b/src/cmake/objc.cmake
@@ -16,6 +16,7 @@ set(objc_imap_files
   objc/imap/MCOIMAPCapabilityOperation.mm
   objc/imap/MCOIMAPCopyMessagesOperation.mm
   objc/imap/MCOIMAPFetchContentOperation.mm
+  objc/imap/MCOIMAPFetchParsedContentOperation.mm
   objc/imap/MCOIMAPFetchFoldersOperation.mm
   objc/imap/MCOIMAPFetchMessagesOperation.mm
   objc/imap/MCOIMAPFetchNamespaceOperation.mm
@@ -84,7 +85,7 @@ set(objc_nntp_files
   objc/nntp/MCONNTPFetchOverviewOperation.mm
   objc/nntp/MCONNTPFetchServerTimeOperation.mm
   objc/nntp/MCONNTPOperation.mm
-  objc/nntp/MCONNTPSession.mm	
+  objc/nntp/MCONNTPSession.mm
 )
 
 set(objc_utils_files

--- a/src/cmake/public-headers.cmake
+++ b/src/cmake/public-headers.cmake
@@ -86,6 +86,7 @@ async/imap/MCIMAPAppendMessageOperation.h
 async/imap/MCIMAPCopyMessagesOperation.h
 async/imap/MCIMAPFetchMessagesOperation.h
 async/imap/MCIMAPFetchContentOperation.h
+async/imap/MCIMAPFetchParsedContentOperation.h
 async/imap/MCIMAPIdleOperation.h
 async/imap/MCIMAPFolderInfoOperation.h
 async/imap/MCIMAPFolderStatusOperation.h
@@ -160,6 +161,7 @@ objc/imap/MCOIMAPAppendMessageOperation.h
 objc/imap/MCOIMAPCopyMessagesOperation.h
 objc/imap/MCOIMAPFetchMessagesOperation.h
 objc/imap/MCOIMAPFetchContentOperation.h
+objc/imap/MCOIMAPFetchParsedContentOperation.h
 objc/imap/MCOIMAPSearchOperation.h
 objc/imap/MCOIMAPIdleOperation.h
 objc/imap/MCOIMAPFetchNamespaceOperation.h

--- a/src/objc/imap/MCOIMAP.h
+++ b/src/objc/imap/MCOIMAP.h
@@ -29,6 +29,7 @@
 #import <MailCore/MCOIMAPCopyMessagesOperation.h>
 #import <MailCore/MCOIMAPFetchMessagesOperation.h>
 #import <MailCore/MCOIMAPFetchContentOperation.h>
+#import <MailCore/MCOIMAPFetchParsedContentOperation.h>
 #import <MailCore/MCOIMAPSearchOperation.h>
 #import <MailCore/MCOIMAPIdleOperation.h>
 #import <MailCore/MCOIMAPFetchNamespaceOperation.h>

--- a/src/objc/imap/MCOIMAPFetchParsedContentOperation.h
+++ b/src/objc/imap/MCOIMAPFetchParsedContentOperation.h
@@ -1,0 +1,44 @@
+//
+//  MCOIMAPFetchParsedContentOperation.h
+//  mailcore2
+//
+//  Created by DINH Viêt Hoà on 3/25/13.
+//  Copyright (c) 2013 MailCore. All rights reserved.
+//
+
+#ifndef MAILCORE_MCOIMAPFETCHPARSEDCONTENTOPERATION_H
+
+#define MAILCORE_MCOIMAPFETCHPARSEDCONTENTOPERATION_H
+
+/**
+ This class implements an operation to fetch the parsed content of a message.
+*/
+
+#import <MailCore/MCOIMAPBaseOperation.h>
+#import <MailCore/MCOConstants.h>
+
+@class MCOMessageParser;
+
+@interface MCOIMAPFetchParsedContentOperation : MCOIMAPBaseOperation
+
+/**
+ This block will be called as bytes are received from the network
+*/
+@property (nonatomic, copy) MCOIMAPBaseOperationProgressBlock progress;
+
+/**
+ Starts the asynchronous fetch operation.
+
+ @param completionBlock Called when the operation is finished.
+
+ - On success `error` will be nil and `parser` will contain the requested message
+
+ - On failure, `error` will be set with `MCOErrorDomain` as domain and an
+   error code available in `MCOConstants.h`, `data` will be nil
+*/
+
+- (void) start:(void (^)(NSError * error, MCOMessageParser * parser))completionBlock;
+
+@end
+
+#endif

--- a/src/objc/imap/MCOIMAPFetchParsedContentOperation.mm
+++ b/src/objc/imap/MCOIMAPFetchParsedContentOperation.mm
@@ -1,0 +1,84 @@
+//
+//  MCOIMAPFetchParsedContentOperation.m
+//  mailcore2
+//
+//  Created by DINH Viêt Hoà on 3/25/13.
+//  Copyright (c) 2013 MailCore. All rights reserved.
+//
+
+#import "MCOIMAPFetchParsedContentOperation.h"
+
+#include "MCAsyncIMAP.h"
+
+#import "MCOMessageParser.h"
+#import "MCOOperation+Private.h"
+#import "MCOUtils.h"
+
+typedef void (^CompletionType)(NSError *error, NSData * data);
+
+@implementation MCOIMAPFetchParsedContentOperation {
+    CompletionType _completionBlock;
+    MCOIMAPBaseOperationProgressBlock _progress;
+}
+
+@synthesize progress = _progress;
+
+#define nativeType mailcore::IMAPFetchParsedContentOperation
+
++ (void) load
+{
+    MCORegisterClass(self, &typeid(nativeType));
+}
+
++ (NSObject *) mco_objectWithMCObject:(mailcore::Object *)object
+{
+    nativeType * op = (nativeType *) object;
+    return [[[self alloc] initWithMCOperation:op] autorelease];
+}
+
+- (void) dealloc
+{
+    [_progress release];
+    [_completionBlock release];
+    [super dealloc];
+}
+
+- (void) start:(void (^)(NSError *error, MCOMessageParser * parser))completionBlock {
+    _completionBlock = [completionBlock copy];
+    [self start];
+}
+
+- (void) cancel
+{
+    [_completionBlock release];
+    _completionBlock = nil;
+    [super cancel];
+}
+
+- (void) operationCompleted
+{
+    if (_completionBlock == NULL)
+        return;
+
+    nativeType *op = MCO_NATIVE_INSTANCE;
+    if (op->error() == mailcore::ErrorNone) {
+        if (op->parser()) {
+            _completionBlock(nil, MCO_TO_OBJC(op->parser()));
+        } else {
+            _completionBlock(nil, nil);
+        }
+    } else {
+        _completionBlock([NSError mco_errorWithErrorCode:op->error()], nil);
+    }
+    [_completionBlock release];
+    _completionBlock = nil;
+}
+
+- (void) bodyProgress:(unsigned int)current maximum:(unsigned int)maximum
+{
+    if (_progress != NULL) {
+        _progress(current, maximum);
+    }
+}
+
+@end

--- a/src/objc/imap/MCOIMAPSession.mm
+++ b/src/objc/imap/MCOIMAPSession.mm
@@ -369,6 +369,34 @@ MCO_OBJC_SYNTHESIZE_SCALAR(dispatch_queue_t, dispatch_queue_t, setDispatchQueue,
     return [self fetchMessageOperationWithFolder:folder number:number urgent:NO];
 }
 
+- (MCOIMAPFetchParsedContentOperation *) fetchParsedMessageOperationWithFolder:(NSString *)folder
+                                                                           uid:(uint32_t)uid
+                                                                        urgent:(BOOL)urgent
+{
+    IMAPFetchParsedContentOperation * coreOp = MCO_NATIVE_INSTANCE->fetchParsedMessageByUIDOperation([folder mco_mcString], uid, urgent);
+    return MCO_TO_OBJC_OP(coreOp);
+}
+
+- (MCOIMAPFetchParsedContentOperation *) fetchParsedMessageOperationWithFolder:(NSString *)folder
+                                                                           uid:(uint32_t)uid
+{
+    return [self fetchParsedMessageOperationWithFolder:folder uid:uid urgent:NO];
+}
+
+- (MCOIMAPFetchParsedContentOperation *) fetchParsedMessageOperationWithFolder:(NSString *)folder
+                                                                        number:(uint32_t)number
+                                                                        urgent:(BOOL)urgent
+{
+    IMAPFetchParsedContentOperation * coreOp = MCO_NATIVE_INSTANCE->fetchParsedMessageByNumberOperation([folder mco_mcString], number, urgent);
+    return MCO_TO_OBJC_OP(coreOp);
+}
+
+- (MCOIMAPFetchParsedContentOperation *) fetchParsedMessageOperationWithFolder:(NSString *)folder
+                                                                        number:(uint32_t)number
+{
+    return [self fetchParsedMessageOperationWithFolder:folder number:number urgent:NO];
+}
+
 - (MCOIMAPFetchContentOperation *) fetchMessageAttachmentByUIDOperationWithFolder:(NSString *)folder
                                                                               uid:(uint32_t)uid
                                                                            partID:(NSString *)partID


### PR DESCRIPTION
This avoids the copying of Data to NSData to Data which happens with the current approach. In one test case, a message with an ~18 MB attachment, the current (copying) approach peaked at ~150 MB of memory usage in my app. This new approach peaks at ~65 MB. Another test case, which often caused iOS to terminate my app, now peaks at ~90 MB. In addition to the improved memory usage this approach also means that message parsing is performed asynchronously.
