### PR TITLE
Add support to SMTP check account without from

### DIFF
--- a/src/core/smtp/MCSMTPSession.cc
+++ b/src/core/smtp/MCSMTPSession.cc
@@ -558,6 +558,9 @@ void SMTPSession::checkAccount(Address * from, ErrorCode * pError)
     if (* pError != ErrorNone) {
         return;
     }
+    if (!from) {
+        return;
+    }
     r = mailsmtp_mail(mSmtp, MCUTF8(from->mailbox()));
     if (r == MAILSMTP_ERROR_STREAM) {
         * pError = ErrorConnection;


### PR DESCRIPTION
We need only login check and  `MAIL FROM` check is unnecessary.
Some SMTP server rejects multi `MAIL FROM`, accepts only once.
So, `checkAccountOperationWithFrom:@"example@example.com"` then `sendOperationWithData:data` is rejected.

If you want `MCOSMTPSession#checkAccountOperation` instead of `MCOSMTPSession#checkAccountOperationWithFrom:nil`, I will send another pull-request to do that.
