### PR TITLE
Minor improvement in '.gitignore' file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ DerivedData
 
 #CocoaPods
 Pods
+Podfile.lock


### PR DESCRIPTION
When you work in a team, it is really useful to have 'Podfile.lock' in gitignore as well. In a case when this file IS under version control and your teammate added something into 'Podfile', installed new pods on his machine and then you are pulling his fixes into your working copy - your working copy seems to be consistent for Cocoapods (because Podfile and Podfile.lock are in sync), but in fact your working copy is missing a new pod files, so you'll get build errors and will wonder what happens. But if we keep Podfile.lock in gitignore - you easily will fix that by just running standard 'pod install' command in Terminal.
