### PR TITLE
Added assertion to check folder isn't NULL

### DIFF
--- a/src/objc/imap/MCOIMAPSession.mm
+++ b/src/objc/imap/MCOIMAPSession.mm
@@ -615,7 +615,6 @@ MCO_OBJC_SYNTHESIZE_SCALAR(dispatch_queue_t, dispatch_queue_t, setDispatchQueue,
 - (MCOIMAPMessageRenderingOperation *) htmlBodyRenderingOperationWithMessage:(MCOIMAPMessage *)message
                                                                       folder:(NSString *)folder
 {
-    assert(folder != NULL);
     IMAPMessageRenderingOperation * coreOp = MCO_NATIVE_INSTANCE->htmlBodyRenderingOperation(MCO_FROM_OBJC(IMAPMessage, message), [folder mco_mcString]);
     return MCO_TO_OBJC_OP(coreOp);
 }
@@ -630,7 +629,6 @@ MCO_OBJC_SYNTHESIZE_SCALAR(dispatch_queue_t, dispatch_queue_t, setDispatchQueue,
 - (MCOIMAPMessageRenderingOperation *) plainTextBodyRenderingOperationWithMessage:(MCOIMAPMessage *)message
                                                                            folder:(NSString *)folder
 {
-    assert(folder != NULL);
     return [self plainTextBodyRenderingOperationWithMessage:message folder:folder stripWhitespace:YES];
 }
 


### PR DESCRIPTION
This PR asserts that the folder string isn't NULL before returning the operation. It's based on [this](http://stackoverflow.com/questions/27567166/mailcore-plaintextbodyrenderingoperationwithmessage-returns-nil/27567463) StackOverflow post.
