### PR TITLE
use charset "IMAP-mailbox-name" instead of "mutf-7" when opening icu con...

### DIFF
--- a/src/core/basetypes/MCString.cpp
+++ b/src/core/basetypes/MCString.cpp
@@ -1336,12 +1336,13 @@ void String::appendBytes(const char * bytes, unsigned int length, const char * c
         }
     }
 #else
+    const char * icu_charset = (strcasecmp(charset, "mutf-7") == 0) ? "IMAP-mailbox-name" : charset;
     UErrorCode err;
     
     err = U_ZERO_ERROR;
-    UConverter * converter = ucnv_open(charset, &err); 
+    UConverter * converter = ucnv_open(icu_charset, &err);
     if (converter == NULL) {
-        MCLog("invalid charset %s %i", charset, err);
+        MCLog("invalid charset %s %i", icu_charset, err);
         return;
     }
     
@@ -2119,13 +2120,14 @@ Data * String::dataUsingEncoding(const char * charset)
     
     return data;
 #else
+    const char * icu_charset = (strcasecmp(charset, "mutf-7") == 0) ? "IMAP-mailbox-name" : charset;
     UErrorCode err;
     Data * data;
     
     err = U_ZERO_ERROR;
-    UConverter * converter = ucnv_open(charset, &err); 
+    UConverter * converter = ucnv_open(icu_charset, &err);
     if (converter == NULL) {
-        MCLog("invalid charset %s %i", charset, err);
+        MCLog("invalid charset %s %i", icu_charset, err);
         return NULL;
     }
     


### PR DESCRIPTION
ucnv_open("mutf-7", &err) always fails and returns NULL,
we should use "IMAP-mailbox-name" to open the UConverter
