### PR TITLE
Fixed crash in OperationQueue

### DIFF
--- a/src/core/basetypes/MCOperationQueue.cpp
+++ b/src/core/basetypes/MCOperationQueue.cpp
@@ -104,7 +104,10 @@ void OperationQueue::runOperations()
             
             retain(); // (2)
 #if __APPLE__
-            performMethodOnDispatchQueue((Object::Method) &OperationQueue::stoppedOnMainThread, NULL, mDispatchQueue, true);
+            dispatch_queue_t queue = mDispatchQueue;
+            dispatch_retain(queue);
+            performMethodOnDispatchQueue((Object::Method) &OperationQueue::stoppedOnMainThread, NULL, queue, true);
+            dispatch_release(queue);
 #else
             performMethodOnMainThread((Object::Method) &OperationQueue::stoppedOnMainThread, NULL, true);
 #endif


### PR DESCRIPTION
There is possible a situation when dispatch_release(mDispatchQueue) in destructor destroys the queue while execution stoppedOnMainThread method.

Test code:

```obj-c
    MCOIMAPSession *session = ...
    
    @autoreleasepool {
        dispatch_queue_t queue = dispatch_queue_create("Test", DISPATCH_QUEUE_SERIAL);
        session.dispatchQueue = queue;
    }
    
    dispatch_async(session.dispatchQueue, ^{
        [[session checkAccountOperation] start:^(NSError *error) {
            completion(error);
            
            dispatch_async(session.dispatchQueue, ^{
                [[session disconnectOperation] start:^(NSError *error) {
                }];
            });
        }];
    });
```
