### PR TITLE
Fixed MCOIMAPIdentity initialization bug

### DIFF
--- a/src/objc/imap/MCOIMAPIdentity.mm
+++ b/src/objc/imap/MCOIMAPIdentity.mm
@@ -23,6 +23,15 @@
     MCORegisterClass(self, &typeid(nativeType));
 }
 
+- (id) init
+{
+    mailcore::IMAPIdentity * identity = new mailcore::IMAPIdentity();
+    self = [self initWithMCIdentity:identity];
+    identity->release();
+
+    return self;
+}
+
 - (id) initWithMCIdentity:(mailcore::IMAPIdentity *)identity
 {
     self = [super init];


### PR DESCRIPTION
There was no init method to initialize the native type instance variable `_nativeIdentity`. So codes like below will crash:
```objective-c
MCOIMAPIdentity *identity = [MCOIMAPIdentity identityWithVendor:@"Mozilla" name:@"Thunderbird" version:@"17.0.5"];
```