### PR TITLE
Update com_libmailcore_IndexSet.cpp

### DIFF
--- a/src/java/native/com_libmailcore_IndexSet.cpp
+++ b/src/java/native/com_libmailcore_IndexSet.cpp
@@ -131,7 +131,7 @@ JNIEXPORT jobject JNICALL Java_com_libmailcore_IndexSet_allRanges
     jmethodID constructor = env->GetMethodID(cls, "<init>", "(I)V");
     unsigned int count = MC_JAVA_NATIVE_INSTANCE->rangesCount();
     jobject javaVector = env->NewObject(cls, constructor, count);
-    jmethodID method = env->GetMethodID(cls, "add", "(Ljava.lang.Object;)Z");
+    jmethodID method = env->GetMethodID(cls, "add", "(Ljava/lang/Object;)Z");
     Range * ranges = MC_JAVA_NATIVE_INSTANCE->allRanges();
     for(unsigned int i = 0 ; i < count ; i ++) {
         jobject javaObject = rangeToJava(env, ranges[i]);


### PR DESCRIPTION
In JNIEXPORT jobject JNICALL Java_com_libmailcore_IndexSet_allRanges
parameter passed is incorrect causing a crash in GetMethodID
    jmethodID method = env->GetMethodID(cls, "add", "(Ljava.lang.Object;)Z");
should be 
    jmethodID method = env->GetMethodID(cls, "add", "(Ljava/lang/Object;)Z");