### PR TITLE
MCSMTPSession: some MS-Exchange SMTP servers reply with permission pr…

### DIFF
--- a/src/core/smtp/MCSMTPSession.cpp
+++ b/src/core/smtp/MCSMTPSession.cpp
@@ -673,11 +673,11 @@ void SMTPSession::sendMessage(Address * from, Array * recipients, Data * message
     }
     else if (r != MAILSMTP_NO_ERROR) {
         if ((responseCode == 550) && (response != NULL)) {
-            if (response->hasPrefix(MCSTR("5.3.4"))) {
+            if (response->hasPrefix(MCSTR("5.3.4 "))) {
                 * pError = ErrorNeedsConnectToWebmail;
                 goto err;
             }
-            else if (response->hasPrefix(MCSTR("5.7.1 Client does not have permissions to send as this sender"))) {
+            else if (response->hasPrefix(MCSTR("5.7.1 "))) {
                 * pError = ErrorSendMessageNotAllowed;
                 goto err;
             }


### PR DESCRIPTION
Some MS-Exchange SMTP servers reply with permission problem undetectable by mailcore. Catch it and set specific error code instead of common one. 

PS. Prefix "5.7.1" is too common to make decision about permission problems based on it. It can also mean "Unable to relay". That's why I use full error message comparison.