### PR TITLE
Include List Converter in javaToMCObject

### DIFF
--- a/src/java/TypesUtils.cpp
+++ b/src/java/TypesUtils.cpp
@@ -437,6 +437,9 @@ Object * mailcore::javaToMCObject(JNIEnv * env, jobject obj)
     else if (isJavaMap(env, obj)) {
         return arrayJavaToObjectConverter(env, obj);
     }
+    else if (isJavaList(env, obj)) {
+        return arrayJavaToObjectConverter(env, obj);
+    }
     else {
         Object * result = NULL;
         


### PR DESCRIPTION
Converter for Java List not included in javaToMCObject. All Java List Parameters in methods will crash as the converter is not found.