### PR TITLE
Fix fetch article method

### DIFF
--- a/src/async/nntp/MCNNTPAsyncSession.cpp
+++ b/src/async/nntp/MCNNTPAsyncSession.cpp
@@ -200,11 +200,6 @@ NNTPFetchArticleOperation * NNTPAsyncSession::fetchArticleByMessageIDOperation(S
     return op;
 }
 
-NNTPFetchArticleOperation * NNTPAsyncSession::fetchArticleByMessageIDOperation(String *groupName, String *messageID)
-{
-    return this->fetchArticleByMessageIDOperation(messageID);
-}
-
 NNTPFetchOverviewOperation * NNTPAsyncSession::fetchOverviewOperationWithIndexes(String * groupName, IndexSet * indexes)
 {
     NNTPFetchOverviewOperation * op = new NNTPFetchOverviewOperation();

--- a/src/async/nntp/MCNNTPAsyncSession.cpp
+++ b/src/async/nntp/MCNNTPAsyncSession.cpp
@@ -191,14 +191,18 @@ NNTPFetchArticleOperation * NNTPAsyncSession::fetchArticleOperation(String * gro
     return op;
 }
 
-NNTPFetchArticleOperation * NNTPAsyncSession::fetchArticleByMessageIDOperation(String *groupName, String *messageID)
+NNTPFetchArticleOperation * NNTPAsyncSession::fetchArticleByMessageIDOperation(String *messageID)
 {
     NNTPFetchArticleOperation * op = new NNTPFetchArticleOperation();
     op->setSession(this);
-    op->setGroupName(groupName);
     op->setMessageID(messageID);
     op->autorelease();
     return op;
+}
+
+NNTPFetchArticleOperation * NNTPAsyncSession::fetchArticleByMessageIDOperation(String *groupName, String *messageID)
+{
+    return this->fetchArticleByMessageIDOperation(messageID);
 }
 
 NNTPFetchOverviewOperation * NNTPAsyncSession::fetchOverviewOperationWithIndexes(String * groupName, IndexSet * indexes)

--- a/src/async/nntp/MCNNTPAsyncSession.h
+++ b/src/async/nntp/MCNNTPAsyncSession.h
@@ -64,7 +64,6 @@ namespace mailcore {
         
         virtual NNTPFetchArticleOperation * fetchArticleOperation(String *groupName, unsigned int index);
         virtual NNTPFetchArticleOperation * fetchArticleByMessageIDOperation(String * messageID);
-        virtual NNTPFetchArticleOperation * fetchArticleByMessageIDOperation(String * groupname, String * messageID);
         
         virtual NNTPFetchOverviewOperation * fetchOverviewOperationWithIndexes(String * groupName, IndexSet * indexes);
         

--- a/src/async/nntp/MCNNTPAsyncSession.h
+++ b/src/async/nntp/MCNNTPAsyncSession.h
@@ -63,6 +63,7 @@ namespace mailcore {
         virtual NNTPFetchHeaderOperation * fetchHeaderOperation(String * groupName, unsigned int index);
         
         virtual NNTPFetchArticleOperation * fetchArticleOperation(String *groupName, unsigned int index);
+        virtual NNTPFetchArticleOperation * fetchArticleByMessageIDOperation(String * messageID);
         virtual NNTPFetchArticleOperation * fetchArticleByMessageIDOperation(String * groupname, String * messageID);
         
         virtual NNTPFetchOverviewOperation * fetchOverviewOperationWithIndexes(String * groupName, IndexSet * indexes);

--- a/src/async/nntp/MCNNTPFetchArticleOperation.cpp
+++ b/src/async/nntp/MCNNTPFetchArticleOperation.cpp
@@ -65,7 +65,7 @@ void NNTPFetchArticleOperation::main()
     if (mMessageID == NULL) {
         mData = session()->session()->fetchArticle(mGroupName, mMessageIndex, this, &error);
     } else {
-        mData = session()->session()->fetchArticleByMessageID(mGroupName, mMessageID, &error);
+        mData = session()->session()->fetchArticleByMessageID(mMessageID, &error);
     }
     MC_SAFE_RETAIN(mData);
     setError(error);

--- a/src/core/nntp/MCNNTPSession.cpp
+++ b/src/core/nntp/MCNNTPSession.cpp
@@ -493,11 +493,6 @@ Data * NNTPSession::fetchArticleByMessageID(String * messageID, ErrorCode * pErr
     return result;
 }
 
-Data * NNTPSession::fetchArticleByMessageID(String * groupName, String * messageID, ErrorCode * pError)
-{
-    return this->fetchArticleByMessageID(messageID, pError);
-}
-
 time_t NNTPSession::fetchServerDate(ErrorCode * pError) {
     int r;
     struct tm time;

--- a/src/core/nntp/MCNNTPSession.cpp
+++ b/src/core/nntp/MCNNTPSession.cpp
@@ -464,7 +464,7 @@ Data * NNTPSession::fetchArticle(String *groupName, unsigned int index, NNTPProg
     return result;
 }
 
-Data * NNTPSession::fetchArticleByMessageID(String * groupName, String * messageID, ErrorCode * pError)
+Data * NNTPSession::fetchArticleByMessageID(String * messageID, ErrorCode * pError)
 {
     int r;
     char * msgID;
@@ -472,11 +472,6 @@ Data * NNTPSession::fetchArticleByMessageID(String * groupName, String * message
     size_t content_len;
     
     MCLog("fetch article at message-id %s", messageID->UTF8Characters());
-    
-    selectGroup(groupName, pError);
-    if (* pError != ErrorNone) {
-        return NULL;
-    }
     
     msgID = strdup(messageID->UTF8Characters());
     
@@ -496,6 +491,11 @@ Data * NNTPSession::fetchArticleByMessageID(String * groupName, String * message
     * pError = ErrorNone;
     
     return result;
+}
+
+Data * NNTPSession::fetchArticleByMessageID(String * groupName, String * messageID, ErrorCode * pError)
+{
+    return this->fetchArticleByMessageID(messageID, pError);
 }
 
 time_t NNTPSession::fetchServerDate(ErrorCode * pError) {

--- a/src/core/nntp/MCNNTPSession.h
+++ b/src/core/nntp/MCNNTPSession.h
@@ -53,6 +53,7 @@ namespace mailcore {
         virtual IndexSet * fetchAllArticles(String * groupname, ErrorCode * pError);
                 
         virtual Data * fetchArticle(String *groupName, unsigned int index, NNTPProgressCallback * callback, ErrorCode * pError);
+        virtual Data * fetchArticleByMessageID(String * messageID, ErrorCode * pError);
         virtual Data * fetchArticleByMessageID(String * groupname, String * messageID, ErrorCode * pError);
         
         virtual time_t fetchServerDate(ErrorCode * pError);

--- a/src/core/nntp/MCNNTPSession.h
+++ b/src/core/nntp/MCNNTPSession.h
@@ -54,7 +54,6 @@ namespace mailcore {
                 
         virtual Data * fetchArticle(String *groupName, unsigned int index, NNTPProgressCallback * callback, ErrorCode * pError);
         virtual Data * fetchArticleByMessageID(String * messageID, ErrorCode * pError);
-        virtual Data * fetchArticleByMessageID(String * groupname, String * messageID, ErrorCode * pError);
         
         virtual time_t fetchServerDate(ErrorCode * pError);
         

--- a/src/objc/nntp/MCONNTPSession.h
+++ b/src/objc/nntp/MCONNTPSession.h
@@ -138,12 +138,22 @@
 /**
  Returns an operation that will fetch the content of a message with the given messageID.
  
+ MCONNTPFetchArticleOperation * op = [session fetchArticleOperationWithMessageID:@"<MessageID123@mail.google.com>"];
+ [op start:^(NSError * __nullable error, NSData * messageData) {
+ // messageData is the RFC 822 formatted message data.
+ }];
+ */
+- (MCONNTPFetchArticleOperation *) fetchArticleOperationWithMessageID:(NSString *)messageID;
+
+/**
+ Obsolete. Use -fetchArticleOperationWithMessageID: instead.
+ 
  MCONNTPFetchArticleOperation * op = [session fetchArticleOperationWithMessageID:@"<MessageID123@mail.google.com>" inGroup:@"comp.lang.c"];
  [op start:^(NSError * __nullable error, NSData * messageData) {
  // messageData is the RFC 822 formatted message data.
  }];
  */
-- (MCONNTPFetchArticleOperation *) fetchArticleOperationWithMessageID:(NSString *)messageID inGroup:(NSString *)group;
+- (MCONNTPFetchArticleOperation *) fetchArticleOperationWithMessageID:(NSString *)messageID inGroup:(NSString * __nullable)group;
 
 /**
  Returns an operation that will fetch the server's date and time.

--- a/src/objc/nntp/MCONNTPSession.h
+++ b/src/objc/nntp/MCONNTPSession.h
@@ -153,7 +153,7 @@
  // messageData is the RFC 822 formatted message data.
  }];
  */
-- (MCONNTPFetchArticleOperation *) fetchArticleOperationWithMessageID:(NSString *)messageID inGroup:(NSString * __nullable)group;
+- (MCONNTPFetchArticleOperation *) fetchArticleOperationWithMessageID:(NSString *)messageID inGroup:(NSString * __nullable)group DEPRECATED_ATTRIBUTE;
 
 /**
  Returns an operation that will fetch the server's date and time.

--- a/src/objc/nntp/MCONNTPSession.mm
+++ b/src/objc/nntp/MCONNTPSession.mm
@@ -176,9 +176,13 @@ MCO_OBJC_SYNTHESIZE_SCALAR(dispatch_queue_t, dispatch_queue_t, setDispatchQueue,
     return MCO_TO_OBJC_OP(coreOp);
 }
 
-- (MCONNTPFetchArticleOperation *) fetchArticleOperationWithMessageID:(NSString *)messageID inGroup:(NSString *)group {
-    mailcore::NNTPFetchArticleOperation * coreOp = MCO_NATIVE_INSTANCE->fetchArticleByMessageIDOperation(MCO_FROM_OBJC(mailcore::String, group), MCO_FROM_OBJC(mailcore::String, messageID));
+- (MCONNTPFetchArticleOperation *) fetchArticleOperationWithMessageID:(NSString *)messageID {
+    mailcore::NNTPFetchArticleOperation * coreOp = MCO_NATIVE_INSTANCE->fetchArticleByMessageIDOperation(MCO_FROM_OBJC(mailcore::String, messageID));
     return MCO_TO_OBJC_OP(coreOp);
+}
+
+- (MCONNTPFetchArticleOperation *) fetchArticleOperationWithMessageID:(NSString *)messageID inGroup:(NSString * __nullable)group {
+    return [self fetchArticleOperationWithMessageID:messageID];
 }
 
 - (MCONNTPFetchOverviewOperation *)fetchOverviewOperationWithIndexes:(MCOIndexSet *)indexes inGroup:(NSString *)group {


### PR DESCRIPTION
This is to fix [the issue I just posted](https://github.com/MailCore/mailcore2/issues/1318). As the [NNTP spec](https://www.rfc-editor.org/rfc/rfc3977.txt) implies in Section 6.2, since retrieving an article by Message-ID isn't allowed to alter the current group or article-number pointers (which may be NULL), the operation doesn't need them to be specifically set in the first place. This issue was introduced into this library by unnecessarily setting the group pointer in "MCNNTPSession.cpp" and cascading the requirements.

I don't know if there are any more files (like tests) that need to be changed. I don't have a development setup for this computer & project; I just noticed the error by inspection and branched-and-fixed the files through the web interface without a compile-and-test. (I don't know if fixes can be merged (rebased?) from the web interface; said interface had me commit each file individually.)

If you don't mind breaking backwards compatibility, the older methods could be purged.
