### PR TITLE
Fixed identity request

### DIFF
--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -3259,7 +3259,12 @@ IMAPIdentity * IMAPSession::identity(IMAPIdentity * clientIdentity, ErrorCode * 
         String * responseKey;
         String * responseValue;
         responseKey = String::stringWithUTF8Characters(param->idpa_name);
-        responseValue = String::stringWithUTF8Characters(param->idpa_value);
+        if (param->idpa_value != NULL) {
+            responseValue = String::stringWithUTF8Characters(param->idpa_value);
+        }
+        else {
+            responseValue = NULL;
+        }
         result->setInfoForKey(responseKey, responseValue);
     }
 


### PR DESCRIPTION
MailCore2 crashes if server responses to identity request with next response:

```
* ID ("name" "Cyrus IMAPD" "version" "v2.2.13-Debian-2.2.13-19+squeeze3 2006/12/19 19:32:59" "vendor" "Project Cyrus" "support-url" "http://asg.web.cmu.edu/cyrus" "os" "Linux" "os-version" "2.6.32-5-amd64" "environment" "Built w/Cyrus SASL 2.1.23; Running w/Cyrus SASL 2.1.23; Built w/Berkeley DB 4.7.25: (May 15, 2008); Running w/Berkeley DB 4.7.25: (May 15, 2008); Built w/OpenSSL 0.9.8o 01 Jun 2010; Running w/OpenSSL 0.9.8o 01 Jun 2010; CMU Sieve 2.2; TCP Wrappers; NET-SNMP; mmap = shared; lock = fcntl; nonblock = fcntl; idle = no" "backend-url" NIL)
```