### PR TITLE
Add Designated Initializers

### DIFF
--- a/src/core/smtp/MCSMTPSession.cpp
+++ b/src/core/smtp/MCSMTPSession.cpp
@@ -547,7 +547,8 @@ void SMTPSession::login(ErrorCode * pError)
             
             if (mOAuth2Token == NULL) {
                 r = MAILSMTP_ERROR_STREAM;
-            } else {
+            } 
+            else {
                 r = mailsmtp_oauth2_outlook_authenticate(mSmtp, utf8Username, MCUTF8(mOAuth2Token));
             }
             break;

--- a/src/objc/abstract/MCOAbstractMessage.h
+++ b/src/objc/abstract/MCOAbstractMessage.h
@@ -56,4 +56,8 @@ namespace mailcore {
 
 @end
 
+@interface MCOAbstractMessage (MCOUnavailable)
+- (id) init NS_UNAVAILABLE;
+@end
+
 #endif

--- a/src/objc/abstract/MCOAbstractMessage.h
+++ b/src/objc/abstract/MCOAbstractMessage.h
@@ -57,7 +57,10 @@ namespace mailcore {
 @end
 
 @interface MCOAbstractMessage (MCOUnavailable)
-- (id) init NS_UNAVAILABLE;
+
+/** Do not invoke this directly */
+- (id) init;
+
 @end
 
 #endif

--- a/src/objc/abstract/MCOAbstractMessage.mm
+++ b/src/objc/abstract/MCOAbstractMessage.mm
@@ -18,7 +18,7 @@
 #import "NSString+MCO.h"
 
 @interface MCOAbstractMessage ()
-- (id)init NS_DESIGNATED_INITIALIZER;
+- (id) init NS_DESIGNATED_INITIALIZER;
 @end
 
 @implementation MCOAbstractMessage {

--- a/src/objc/abstract/MCOAbstractMessage.mm
+++ b/src/objc/abstract/MCOAbstractMessage.mm
@@ -17,10 +17,6 @@
 #import "NSObject+MCO.h"
 #import "NSString+MCO.h"
 
-@interface MCOAbstractMessage ()
-- (id) init NS_DESIGNATED_INITIALIZER;
-@end
-
 @implementation MCOAbstractMessage {
     mailcore::AbstractMessage * _message;
 }
@@ -34,9 +30,9 @@
 
 - (id) init
 {
+    self = [self initWithMCMessage:NULL];
     MCAssert(0);
-    [self release];
-    return (self = nil);
+    return nil;
 }
 
 - (id) initWithMCMessage:(mailcore::AbstractMessage *)message

--- a/src/objc/abstract/MCOAbstractMessage.mm
+++ b/src/objc/abstract/MCOAbstractMessage.mm
@@ -17,6 +17,10 @@
 #import "NSObject+MCO.h"
 #import "NSString+MCO.h"
 
+@interface MCOAbstractMessage ()
+- (id)init NS_DESIGNATED_INITIALIZER;
+@end
+
 @implementation MCOAbstractMessage {
     mailcore::AbstractMessage * _message;
 }

--- a/src/objc/abstract/MCOAbstractMessage.mm
+++ b/src/objc/abstract/MCOAbstractMessage.mm
@@ -30,9 +30,9 @@
 
 - (id) init
 {
-    self = [self initWithMCMessage:NULL];
     MCAssert(0);
-    return nil;
+    [self release];
+    return (self = nil);
 }
 
 - (id) initWithMCMessage:(mailcore::AbstractMessage *)message

--- a/src/objc/abstract/MCOAbstractPart.h
+++ b/src/objc/abstract/MCOAbstractPart.h
@@ -109,4 +109,8 @@ namespace mailcore {
 
 @end
 
+@interface MCOAbstractPart (MCOUnavailable)
+- (id) init NS_UNAVAILABLE;
+@end
+
 #endif

--- a/src/objc/abstract/MCOAbstractPart.mm
+++ b/src/objc/abstract/MCOAbstractPart.mm
@@ -28,9 +28,9 @@
 
 - (id) init
 {
-    self = [self initWithMCPart:NULL];
     MCAssert(0);
-    return nil;
+    [self release];
+    return (self = nil);
 }
 
 - (id) initWithMCPart:(mailcore::AbstractPart *)part

--- a/src/objc/abstract/MCOMessageHeader.h
+++ b/src/objc/abstract/MCOMessageHeader.h
@@ -63,6 +63,9 @@
 /** Returns a header created from RFC 822 data.*/
 + (MCOMessageHeader *) headerWithData:(NSData *)data;
 
+/** Initialize a header with empty RFC 822 data. */
+- (id) init NS_DESIGNATED_INITIALIZER;
+
 /** Initialize a header with RFC 822 data.*/
 - (id) initWithData:(NSData *)data;
 

--- a/src/objc/abstract/MCOMessageHeader.mm
+++ b/src/objc/abstract/MCOMessageHeader.mm
@@ -19,6 +19,11 @@
 #import "MCOAddress.h"
 #import "MCOAddress+Private.h"
 
+@interface MCOMessageHeader ()
+- (id) initWithCoder:(NSCoder *)aDecoder NS_DESIGNATED_INITIALIZER;
+- (id) initWithMCMessageHeader:(mailcore::MessageHeader *)header NS_DESIGNATED_INITIALIZER;
+@end
+
 @implementation MCOMessageHeader {
     mailcore::MessageHeader * _nativeHeader;
 }

--- a/src/objc/nntp/MCONNTPFetchArticleOperation.mm
+++ b/src/objc/nntp/MCONNTPFetchArticleOperation.mm
@@ -60,7 +60,7 @@ private:
     return [[[self alloc] initWithMCOperation:op] autorelease];
 }
 
-- (id)initWithMCOperation:(mailcore::Operation *)op
+- (id) initWithMCOperation:(mailcore::Operation *)op
 {
     self = [super initWithMCOperation:op];
     

--- a/src/objc/nntp/MCONNTPSession.mm
+++ b/src/objc/nntp/MCONNTPSession.mm
@@ -71,7 +71,7 @@ private:
     return MCO_OBJC_BRIDGE_GET(description);
 }
 
-- (id)init {
+- (id) init {
     self = [super init];
     
     _session = new mailcore::NNTPAsyncSession();

--- a/src/objc/pop/MCOPOPFetchMessageOperation.mm
+++ b/src/objc/pop/MCOPOPFetchMessageOperation.mm
@@ -60,7 +60,7 @@ private:
     return [[[self alloc] initWithMCOperation:op] autorelease];
 }
 
-- (id)initWithMCOperation:(mailcore::Operation *)op
+- (id) initWithMCOperation:(mailcore::Operation *)op
 {
     self = [super initWithMCOperation:op];
     

--- a/src/objc/provider/MCOMailProvider.h
+++ b/src/objc/provider/MCOMailProvider.h
@@ -14,9 +14,12 @@
 
 @interface MCOMailProvider : NSObject
 
-@property (nonatomic, copy) NSString * identifier;
+/**
+   Initializes an `MCOMailProvider` object with the info dictionary.
+*/
+- (id) initWithInfo:(NSDictionary *)info NS_DESIGNATED_INITIALIZER;
 
-- (id) initWithInfo:(NSDictionary *)info;
+@property (nonatomic, copy) NSString * identifier;
 
 /**
    A list of ways that you can connect to the IMAP server
@@ -82,5 +85,11 @@
    @return Returns nil if it is unknown
 */
 - (NSString *) importantFolderPath;
+
+@end
+
+@interface MCOMailProvider (MCOUnavailable)
+
+- (id) init NS_UNAVAILABLE;
 
 @end

--- a/src/objc/provider/MCOMailProvider.mm
+++ b/src/objc/provider/MCOMailProvider.mm
@@ -17,6 +17,10 @@
 #import "NSString+MCO.h"
 #import "NSObject+MCO.h"
 
+@interface MCOMailProvider ()
+- (id) initWithMCProvider:(mailcore::MailProvider *)provider NS_DESIGNATED_INITIALIZER;
+@end
+
 @implementation MCOMailProvider {
     mailcore::MailProvider * _provider;
 }
@@ -37,6 +41,13 @@
 {
     mailcore::MailProvider * provider = (mailcore::MailProvider *) object;
     return [[[self alloc] initWithMCProvider:provider] autorelease];
+}
+
+- (id) init
+{
+    MCAssert(0);
+    [self release];
+    return (self = nil);
 }
 
 - (id) initWithInfo:(NSDictionary *)info

--- a/src/objc/provider/MCOMailProvidersManager.mm
+++ b/src/objc/provider/MCOMailProvidersManager.mm
@@ -21,7 +21,7 @@
     static MCOMailProvidersManager * sharedInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedInstance = [[self alloc] init]; \
+        sharedInstance = [[self alloc] init];
     });
     return sharedInstance;
 }

--- a/src/objc/provider/MCONetService.h
+++ b/src/objc/provider/MCONetService.h
@@ -16,6 +16,16 @@
 @interface MCONetService : NSObject <NSCopying>
 
 /**
+   Creates and initializes a `MCONetService` object with the info dictionary.
+*/
++ (MCONetService *) serviceWithInfo:(NSDictionary *)info;
+
+/**
+   Initializes a `MCONetService` object with the given info dictionary.
+*/
+- (id) initWithInfo:(NSDictionary *)info NS_DESIGNATED_INITIALIZER;
+
+/**
    The hostname of the server. [MCONetService hostnameWithEmail:] is recommended
    instead as it can handle services with custom domains 
 */
@@ -27,9 +37,6 @@
 /** What kind of connection type is supported, like SSL, Start TLS, Plain etc. */
 @property (nonatomic, assign) MCOConnectionType connectionType;
 
-+ (MCONetService *) serviceWithInfo:(NSDictionary *)info;
-
-- (id) initWithInfo:(NSDictionary *)info;
 - (NSDictionary *) info;
 
 /** 
@@ -37,5 +44,11 @@
     off the email address
 */
 - (NSString *) hostnameWithEmail:(NSString *)email;
+
+@end
+
+@interface MCONetService (MCOUnavailable)
+
+- (id) init NS_UNAVAILABLE;
 
 @end

--- a/src/objc/provider/MCONetService.mm
+++ b/src/objc/provider/MCONetService.mm
@@ -13,6 +13,10 @@
 #import "NSString+MCO.h"
 #import "NSObject+MCO.h"
 
+@interface MCONetService ()
+- (id) initWithNetService:(mailcore::NetService *)netService NS_DESIGNATED_INITIALIZER;
+@end
+
 @implementation MCONetService {
     mailcore::NetService *_netService;
 }
@@ -38,6 +42,13 @@
 + (MCONetService *) serviceWithInfo:(NSDictionary *)info
 {
     return [[[self alloc] initWithInfo:info] autorelease];
+}
+
+- (id) init
+{
+    MCAssert(0);
+    [self release];
+    return (self = nil);
 }
 
 - (id) initWithInfo:(NSDictionary *)info

--- a/src/objc/rfc822/MCOMessageBuilder.h
+++ b/src/objc/rfc822/MCOMessageBuilder.h
@@ -34,6 +34,9 @@
 
 @interface MCOMessageBuilder : MCOAbstractMessage <NSCopying>
 
+/** Creates and initializes an empty message builder. */
+- (id) init NS_DESIGNATED_INITIALIZER;
+
 /** Main HTML content of the message.*/
 @property (nonatomic, copy, setter=setHTMLBody:) NSString * htmlBody;
 

--- a/src/objc/rfc822/MCOMessageBuilder.mm
+++ b/src/objc/rfc822/MCOMessageBuilder.mm
@@ -13,6 +13,10 @@
 #import "MCOUtils.h"
 #import "MCOAbstractMessageRendererCallback.h"
 
+@interface MCOMessageBuilder ()
+- (id) initWithMCMessage:(mailcore::AbstractMessage *)message NS_DESIGNATED_INITIALIZER;
+@end
+
 @implementation MCOMessageBuilder
 
 #define nativeType mailcore::MessageBuilder
@@ -28,6 +32,11 @@
     self = [super initWithMCMessage:message];
     MC_SAFE_RELEASE(message);
     return self;
+}
+
+- (id) initWithMCMessage:(mailcore::AbstractMessage *)message
+{
+    return [super initWithMCMessage:message];
 }
 
 - (id) copyWithZone:(NSZone *)zone

--- a/src/objc/rfc822/MCOMessageBuilder.mm
+++ b/src/objc/rfc822/MCOMessageBuilder.mm
@@ -26,7 +26,7 @@
     MCORegisterClass(self, &typeid(nativeType));
 }
 
-- (id)init
+- (id) init
 {
     mailcore::MessageBuilder * message = new mailcore::MessageBuilder();
     self = [super initWithMCMessage:message];

--- a/src/objc/rfc822/MCOMessageParser.h
+++ b/src/objc/rfc822/MCOMessageParser.h
@@ -26,7 +26,7 @@
 + (MCOMessageParser *) messageParserWithData:(NSData *)data;
 
 /** data is the RFC 822 formatted message.*/
-- (id) initWithData:(NSData *)data;
+- (id) initWithData:(NSData *)data NS_DESIGNATED_INITIALIZER;
 - (void) dealloc;
 
 /** It's the main part of the message. It can be MCOMessagePart, MCOMultipart or MCOAttachment.*/
@@ -51,6 +51,12 @@
 /** Text rendering of the body of the message. All end of line will be removed and white spaces cleaned up if requested.
  This method can be used to generate the summary of the message.*/
 - (NSString *) plainTextBodyRenderingAndStripWhitespace:(BOOL)stripWhitespace;
+
+@end
+
+@interface MCOMessageParser (MCOUnavailable)
+
+- (instancetype)init NS_UNAVAILABLE;
 
 @end
 

--- a/src/objc/rfc822/MCOMessageParser.mm
+++ b/src/objc/rfc822/MCOMessageParser.mm
@@ -16,6 +16,10 @@
 #import "MCOUtils.h"
 #import "MCOAbstractMessageRendererCallback.h"
 
+@interface MCOMessageParser ()
+- (id) initWithMCMessage:(mailcore::AbstractMessage *)message NS_DESIGNATED_INITIALIZER;
+@end
+
 @implementation MCOMessageParser
 
 #define nativeType mailcore::MessageParser
@@ -42,6 +46,11 @@
     self = [super initWithMCMessage:message];
     MC_SAFE_RELEASE(message);
     return self;
+}
+
+- (id) initWithMCMessage:(mailcore::AbstractMessage *)message
+{
+    return [super initWithMCMessage:message];
 }
 
 - (void) dealloc

--- a/src/objc/utils/MCOOperation.h
+++ b/src/objc/utils/MCOOperation.h
@@ -40,7 +40,7 @@
 
 @interface MCOOperation (MCOUnavailable)
 
-- (instancetype) init NS_UNAVAILABLE;
+- (id) init NS_UNAVAILABLE;
 
 @end
 

--- a/src/objc/utils/MCOOperation.h
+++ b/src/objc/utils/MCOOperation.h
@@ -38,4 +38,10 @@
 
 @end
 
+@interface MCOOperation (MCOUnavailable)
+
+- (instancetype) init NS_UNAVAILABLE;
+
+@end
+
 #endif


### PR DESCRIPTION
Adds designated initializer marks to explicit init methods per the discussion in #1310.  Also makes some initializers unavailable to prevent the kinds of errors in there too.