### PR TITLE
2 new error codes

### DIFF
--- a/src/core/abstract/MCErrorMessage.cpp
+++ b/src/core/abstract/MCErrorMessage.cpp
@@ -46,11 +46,14 @@ static const char * localizedDescriptionTable[] = {
     "An application specific password is required",                                  /** MCOErrorGmailApplicationSpecificPasswordRequired */
     "An error when requesting date",                                                 /** MCOErrorServerDate */
     "No valid server found",                                                         /** MCOErrorNoValidServerFound */
+    NULL,                                                                            /** MCOErrorCustomCommand */
+    "Cannot send message due to possible spam detected by server",                   /** MCOErrorSendMessageSpamSuspected */
+    "User is over the limit for messages allowed to be sent in a single day",        /** MCOErrorSendMessageDailyLimitExceeded */
 };
 
 String * mailcore::errorMessageWithErrorCode(ErrorCode errorCode)
 {
-    if (errorCode < 0) {
+    if (errorCode < 0 || errorCode == ErrorCustomCommand) {
         return NULL;
     }
     if (errorCode >= sizeof(localizedDescriptionTable) / sizeof(localizedDescriptionTable[0])) {

--- a/src/core/abstract/MCErrorMessage.cpp
+++ b/src/core/abstract/MCErrorMessage.cpp
@@ -46,14 +46,14 @@ static const char * localizedDescriptionTable[] = {
     "An application specific password is required",                                  /** MCOErrorGmailApplicationSpecificPasswordRequired */
     "An error when requesting date",                                                 /** MCOErrorServerDate */
     "No valid server found",                                                         /** MCOErrorNoValidServerFound */
-    NULL,                                                                            /** MCOErrorCustomCommand */
+    "Error while running custom command",                                            /** MCOErrorCustomCommand */
     "Cannot send message due to possible spam detected by server",                   /** MCOErrorSendMessageSpamSuspected */
     "User is over the limit for messages allowed to be sent in a single day",        /** MCOErrorSendMessageDailyLimitExceeded */
 };
 
 String * mailcore::errorMessageWithErrorCode(ErrorCode errorCode)
 {
-    if (errorCode < 0 || errorCode == ErrorCustomCommand) {
+    if (errorCode < 0) {
         return NULL;
     }
     if (errorCode >= sizeof(localizedDescriptionTable) / sizeof(localizedDescriptionTable[0])) {

--- a/src/core/abstract/MCMessageConstants.h
+++ b/src/core/abstract/MCMessageConstants.h
@@ -253,8 +253,8 @@ namespace mailcore {
         ErrorServerDate,
         ErrorNoValidServerFound,
         ErrorCustomCommand,
-        ErrorSendMessageSpamSuspected,
-        ErrorSendMessageDailyLimitExceeded
+        ErrorYahooSendMessageSpamSuspected,
+        ErrorYahooSendMessageDailyLimitExceeded
     };
     
     enum PartType {

--- a/src/core/abstract/MCMessageConstants.h
+++ b/src/core/abstract/MCMessageConstants.h
@@ -253,6 +253,8 @@ namespace mailcore {
         ErrorServerDate,
         ErrorNoValidServerFound,
         ErrorCustomCommand,
+        ErrorSendMessageSpamSuspected,
+        ErrorSendMessageDailyLimitExceeded
     };
     
     enum PartType {

--- a/src/core/smtp/MCSMTPSession.cpp
+++ b/src/core/smtp/MCSMTPSession.cpp
@@ -682,12 +682,12 @@ void SMTPSession::sendMessage(Address * from, Array * recipients, Data * message
                 goto err;
             }
         }
-        else if (responseCode == 521 && response->locationOfString(MCSTR("limit")) != -1) {
-            * pError = ErrorSendMessageDailyLimitExceeded;
+        else if (responseCode == 521 && response->locationOfString(MCSTR("over the limit")) != -1) {
+            * pError = ErrorYahooSendMessageDailyLimitExceeded;
             goto err;
         }
         else if (responseCode == 554 && response->locationOfString(MCSTR("spam")) != -1) {
-            * pError = ErrorSendMessageSpamSuspected;
+            * pError = ErrorYahooSendMessageSpamSuspected;
             goto err;
         }
         

--- a/src/core/smtp/MCSMTPSession.cpp
+++ b/src/core/smtp/MCSMTPSession.cpp
@@ -682,6 +682,14 @@ void SMTPSession::sendMessage(Address * from, Array * recipients, Data * message
                 goto err;
             }
         }
+        else if (responseCode == 521 && response->locationOfString(MCSTR("limit")) != -1) {
+            * pError = ErrorSendMessageDailyLimitExceeded;
+            goto err;
+        }
+        else if (responseCode == 554 && response->locationOfString(MCSTR("spam")) != -1) {
+            * pError = ErrorSendMessageSpamSuspected;
+            goto err;
+        }
         
         * pError = ErrorSendMessage;
         MC_SAFE_REPLACE_COPY(String, mLastSMTPResponse, response);

--- a/src/objc/abstract/MCOConstants.h
+++ b/src/objc/abstract/MCOConstants.h
@@ -414,9 +414,9 @@ typedef NS_ENUM(NSInteger, MCOErrorCode) {
     /** Error while running custom command */
     MCOErrorCustomCommand,
     /** Spam was suspected by server */
-    MCOErrorSendMessageSpamSuspected,
+    MCOErrorYahooSendMessageSpamSuspected,
     /** Daily limit of sent messages was hit */
-    MCOErrorSendMessageDailyLimitExceeded,
+    MCOErrorYahooSendMessageDailyLimitExceeded,
     /** The count of all errors */
     MCOErrorCodeCount,
 };

--- a/src/objc/abstract/MCOConstants.h
+++ b/src/objc/abstract/MCOConstants.h
@@ -413,6 +413,10 @@ typedef NS_ENUM(NSInteger, MCOErrorCode) {
     MCOErrorNoValidServerFound,
     /** Error while running custom command */
     MCOErrorCustomCommand,
+    /** Spam was suspected by server */
+    MCOErrorSendMessageSpamSuspected,
+    /** Daily limit of sent messages was hit */
+    MCOErrorSendMessageDailyLimitExceeded,
     /** The count of all errors */
     MCOErrorCodeCount,
 };


### PR DESCRIPTION
Hello,

SMTP server smtp.mail.yahoo.co.jp can reply with 2 custom errors while trying to send mail:

*554 Cannot send message due to possible spam; please visit https://www.yahoo-help.jp/app/ask/p/2494/form/betamail-inquiry for more information*

and

*521 smtp.mail.yahoo.co.jp closing transmission channel. User is over the limit for messages allowed to be sent in a single day*.

MCSMTPSession doesn't treat them and returns common error code 'ErrorSendMessage' that does not reflect the exact reason of fault.

To be able to handle these error cases in our email client (based on mailcore2), I have added two custom error codes.

Can you add them to the mainline mailcore2?

Thank you very much for your attention!

PS. Also I've found and fixed potential bug in MCErrorMessage::errorMessageWithErrorCode() that returns NULL when fed with recently added ErrorCustomCommand code.