### PR TITLE
Prefer instancetype over id in initializers

### DIFF
--- a/src/core/basetypes/MCMainThreadMac.mm
+++ b/src/core/basetypes/MCMainThreadMac.mm
@@ -29,7 +29,7 @@ static void destroyDelayedCall(void * caller);
 @synthesize context = _context;
 @synthesize timer = _timer;
 
-- (id) init
+- (instancetype) init
 {
     self = [super init];
     return self;

--- a/src/objc/abstract/MCOAbstractMessage.h
+++ b/src/objc/abstract/MCOAbstractMessage.h
@@ -24,7 +24,7 @@ namespace mailcore {
 @interface MCOAbstractMessage : NSObject <NSCopying>
 
 #ifdef __cplusplus
-- (id) initWithMCMessage:(mailcore::AbstractMessage *)message NS_DESIGNATED_INITIALIZER;
+- (instancetype) initWithMCMessage:(mailcore::AbstractMessage *)message NS_DESIGNATED_INITIALIZER;
 #endif
 
 /** Header of the message. */

--- a/src/objc/abstract/MCOAbstractMessage.mm
+++ b/src/objc/abstract/MCOAbstractMessage.mm
@@ -28,14 +28,14 @@
     return _message;
 }
 
-- (id) init
+- (instancetype) init
 {
     self = [self initWithMCMessage:NULL];
     MCAssert(0);
     return nil;
 }
 
-- (id) initWithMCMessage:(mailcore::AbstractMessage *)message
+- (instancetype) initWithMCMessage:(mailcore::AbstractMessage *)message
 {
     self = [super init];
     

--- a/src/objc/abstract/MCOAbstractPart.h
+++ b/src/objc/abstract/MCOAbstractPart.h
@@ -50,7 +50,7 @@ namespace mailcore {
 @interface MCOAbstractPart : NSObject <NSCopying>
 
 #ifdef __cplusplus
-- (id) initWithMCPart:(mailcore::AbstractPart *)part NS_DESIGNATED_INITIALIZER;
+- (instancetype) initWithMCPart:(mailcore::AbstractPart *)part NS_DESIGNATED_INITIALIZER;
 #endif
 
 /** Returns type of the part (single / message part / multipart/mixed,
@@ -112,7 +112,7 @@ namespace mailcore {
 @interface MCOAbstractPart (MCOUnavailable)
 
 /** Do not invoke this directly. */
-- (id) init NS_UNAVAILABLE;
+- (instancetype) init NS_UNAVAILABLE;
 
 @end
 

--- a/src/objc/abstract/MCOAbstractPart.mm
+++ b/src/objc/abstract/MCOAbstractPart.mm
@@ -26,14 +26,14 @@
     return _part;
 }
 
-- (id) init
+- (instancetype) init
 {
     self = [self initWithMCPart:NULL];
     MCAssert(0);
     return nil;
 }
 
-- (id) initWithMCPart:(mailcore::AbstractPart *)part
+- (instancetype) initWithMCPart:(mailcore::AbstractPart *)part
 {
     self = [super init];
     

--- a/src/objc/abstract/MCOAddress+Private.h
+++ b/src/objc/abstract/MCOAddress+Private.h
@@ -17,7 +17,7 @@ namespace mailcore {
 
 @interface MCOAddress (Private)
 
-- (id) initWithMCAddress:(mailcore::Address *)address;
+- (instancetype) initWithMCAddress:(mailcore::Address *)address;
 + (MCOAddress *) addressWithMCAddress:(mailcore::Address *)address;
 
 @end

--- a/src/objc/abstract/MCOAddress.mm
+++ b/src/objc/abstract/MCOAddress.mm
@@ -108,7 +108,7 @@ MCO_SYNTHESIZE_NSCODING
 }
 
 
-- (id) init
+- (instancetype) init
 {
     self = [super init];
     
@@ -117,7 +117,7 @@ MCO_SYNTHESIZE_NSCODING
     return self;
 }
 
-- (id) initWithMCAddress:(mailcore::Address *)address
+- (instancetype) initWithMCAddress:(mailcore::Address *)address
 {
     self = [super init];
     

--- a/src/objc/abstract/MCOMessageHeader+Private.h
+++ b/src/objc/abstract/MCOMessageHeader+Private.h
@@ -17,7 +17,7 @@ namespace mailcore {
 
 @interface MCOMessageHeader (Private)
 
-- (id) initWithMCMessageHeader:(mailcore::MessageHeader *)header;
+- (instancetype) initWithMCMessageHeader:(mailcore::MessageHeader *)header;
 + (MCOAddress *) addressWithMCMessageHeader:(mailcore::MessageHeader *)header;
 
 @end

--- a/src/objc/abstract/MCOMessageHeader.h
+++ b/src/objc/abstract/MCOMessageHeader.h
@@ -64,7 +64,7 @@
 + (MCOMessageHeader *) headerWithData:(NSData *)data;
 
 /** Initialize a header with RFC 822 data.*/
-- (id) initWithData:(NSData *)data;
+- (instancetype) initWithData:(NSData *)data;
 
 /** Adds a custom header.*/
 - (void) setExtraHeaderValue:(NSString *)value forName:(NSString *)name;

--- a/src/objc/abstract/MCOMessageHeader.mm
+++ b/src/objc/abstract/MCOMessageHeader.mm
@@ -49,7 +49,7 @@
     return _nativeHeader;
 }
 
-- (id) init
+- (instancetype) init
 {
     self = [super init];
     
@@ -58,7 +58,7 @@
     return self;
 }
 
-- (id) initWithMCMessageHeader:(mailcore::MessageHeader *)header
+- (instancetype) initWithMCMessageHeader:(mailcore::MessageHeader *)header
 {
     self = [super init];
     
@@ -73,7 +73,7 @@
     return [[[MCOMessageHeader alloc] initWithData:data] autorelease];
 }
 
-- (id) initWithData:(NSData *)data
+- (instancetype) initWithData:(NSData *)data
 {
     self = [self init];
     [self importHeadersData:data];

--- a/src/objc/imap/MCOIMAPBaseOperation.mm
+++ b/src/objc/imap/MCOIMAPBaseOperation.mm
@@ -47,7 +47,7 @@ private:
 
 MCO_OBJC_SYNTHESIZE_SCALAR(BOOL, bool, setUrgent, isUrgent)
 
-- (id) initWithMCOperation:(mailcore::Operation *)op
+- (instancetype) initWithMCOperation:(mailcore::Operation *)op
 {
     self = [super initWithMCOperation:op];
     

--- a/src/objc/imap/MCOIMAPFolder.mm
+++ b/src/objc/imap/MCOIMAPFolder.mm
@@ -37,7 +37,7 @@
     return [[[self alloc] initWithMCFolder:folder] autorelease];
 }
 
-- (id) init
+- (instancetype) init
 {
     mailcore::IMAPFolder * folder = new mailcore::IMAPFolder();
     self = [self initWithMCFolder:folder];
@@ -46,7 +46,7 @@
     return self;
 }
 
-- (id) initWithMCFolder:(mailcore::IMAPFolder *)folder
+- (instancetype) initWithMCFolder:(mailcore::IMAPFolder *)folder
 {
     self = [super init];
     

--- a/src/objc/imap/MCOIMAPFolderInfo.mm
+++ b/src/objc/imap/MCOIMAPFolderInfo.mm
@@ -22,7 +22,7 @@
     MCORegisterClass(self, &typeid(nativeType));
 }
 
-- (id) initWithMCFolderInfo:(mailcore::IMAPFolderInfo *)info
+- (instancetype) initWithMCFolderInfo:(mailcore::IMAPFolderInfo *)info
 {
     self = [super init];
 

--- a/src/objc/imap/MCOIMAPFolderStatus.mm
+++ b/src/objc/imap/MCOIMAPFolderStatus.mm
@@ -22,7 +22,7 @@
     MCORegisterClass(self, &typeid(nativeType));
 }
 
-- (id) initWithMCFolderStatus:(mailcore::IMAPFolderStatus *)status
+- (instancetype) initWithMCFolderStatus:(mailcore::IMAPFolderStatus *)status
 {
     self = [super init];
     

--- a/src/objc/imap/MCOIMAPIdentity.mm
+++ b/src/objc/imap/MCOIMAPIdentity.mm
@@ -23,7 +23,7 @@
     MCORegisterClass(self, &typeid(nativeType));
 }
 
-- (id) init
+- (instancetype) init
 {
     mailcore::IMAPIdentity * identity = new mailcore::IMAPIdentity();
     self = [self initWithMCIdentity:identity];
@@ -32,7 +32,7 @@
     return self;
 }
 
-- (id) initWithMCIdentity:(mailcore::IMAPIdentity *)identity
+- (instancetype) initWithMCIdentity:(mailcore::IMAPIdentity *)identity
 {
     self = [super init];
     

--- a/src/objc/imap/MCOIMAPMessage.mm
+++ b/src/objc/imap/MCOIMAPMessage.mm
@@ -24,7 +24,7 @@
     MCORegisterClass(self, &typeid(nativeType));
 }
 
-- (id) init
+- (instancetype) init
 {
     mailcore::IMAPMessage * msg = new mailcore::IMAPMessage();
     self = [self initWithMCMessage:msg];

--- a/src/objc/imap/MCOIMAPNamespace.mm
+++ b/src/objc/imap/MCOIMAPNamespace.mm
@@ -37,7 +37,7 @@
     return [[[self alloc] initWithMCNamespace:ns] autorelease];
 }
 
-- (id) init
+- (instancetype) init
 {
     mailcore::IMAPNamespace * ns = new mailcore::IMAPNamespace();
     self = [self initWithMCNamespace:ns];
@@ -46,7 +46,7 @@
     return self;
 }
 
-- (id) initWithMCNamespace:(mailcore::IMAPNamespace *)ns
+- (instancetype) initWithMCNamespace:(mailcore::IMAPNamespace *)ns
 {
     self = [super init];
     

--- a/src/objc/imap/MCOIMAPNamespaceItem.mm
+++ b/src/objc/imap/MCOIMAPNamespaceItem.mm
@@ -37,7 +37,7 @@
     return [[[self alloc] initWithMCNamespaceItem:item] autorelease];
 }
 
-- (id) init
+- (instancetype) init
 {
     mailcore::IMAPNamespaceItem * item = new mailcore::IMAPNamespaceItem();
     self = [self initWithMCNamespaceItem:item];
@@ -46,7 +46,7 @@
     return self;
 }
 
-- (id) initWithMCNamespaceItem:(mailcore::IMAPNamespaceItem *)item
+- (instancetype) initWithMCNamespaceItem:(mailcore::IMAPNamespaceItem *)item
 {
     self = [super init];
     

--- a/src/objc/imap/MCOIMAPSearchExpression.mm
+++ b/src/objc/imap/MCOIMAPSearchExpression.mm
@@ -42,7 +42,7 @@
     return _nativeExpr;
 }
 
-- (id) initWithMCExpression:(mailcore::IMAPSearchExpression *)expr
+- (instancetype) initWithMCExpression:(mailcore::IMAPSearchExpression *)expr
 {
     self = [super init];
     

--- a/src/objc/imap/MCOIMAPSession.mm
+++ b/src/objc/imap/MCOIMAPSession.mm
@@ -73,7 +73,7 @@ private:
     return _session;
 }
 
-- (id)init {
+- (instancetype) init {
     self = [super init];
     
     _session = new IMAPAsyncSession();

--- a/src/objc/nntp/MCONNTPFetchArticleOperation.mm
+++ b/src/objc/nntp/MCONNTPFetchArticleOperation.mm
@@ -60,7 +60,7 @@ private:
     return [[[self alloc] initWithMCOperation:op] autorelease];
 }
 
-- (id)initWithMCOperation:(mailcore::Operation *)op
+- (instancetype) initWithMCOperation:(mailcore::Operation *)op
 {
     self = [super initWithMCOperation:op];
     

--- a/src/objc/nntp/MCONNTPGroupInfo.mm
+++ b/src/objc/nntp/MCONNTPGroupInfo.mm
@@ -48,7 +48,7 @@
     return MCO_OBJC_BRIDGE_GET(description);
 }
 
-- (id) initWithMCNNTPGroupInfo:(mailcore::NNTPGroupInfo *)info
+- (instancetype) initWithMCNNTPGroupInfo:(mailcore::NNTPGroupInfo *)info
 {
     self = [super init];
     

--- a/src/objc/nntp/MCONNTPSession.mm
+++ b/src/objc/nntp/MCONNTPSession.mm
@@ -71,7 +71,7 @@ private:
     return MCO_OBJC_BRIDGE_GET(description);
 }
 
-- (id)init {
+- (instancetype) init {
     self = [super init];
     
     _session = new mailcore::NNTPAsyncSession();

--- a/src/objc/pop/MCOPOPFetchMessageOperation.mm
+++ b/src/objc/pop/MCOPOPFetchMessageOperation.mm
@@ -60,7 +60,7 @@ private:
     return [[[self alloc] initWithMCOperation:op] autorelease];
 }
 
-- (id)initWithMCOperation:(mailcore::Operation *)op
+- (instancetype) initWithMCOperation:(mailcore::Operation *)op
 {
     self = [super initWithMCOperation:op];
     

--- a/src/objc/pop/MCOPOPMessageInfo.mm
+++ b/src/objc/pop/MCOPOPMessageInfo.mm
@@ -48,7 +48,7 @@
     return MCO_OBJC_BRIDGE_GET(description);
 }
 
-- (id) initWithMCPOPMessageInfo:(mailcore::POPMessageInfo *)info
+- (instancetype) initWithMCPOPMessageInfo:(mailcore::POPMessageInfo *)info
 {
     self = [super init];
     

--- a/src/objc/pop/MCOPOPSession.mm
+++ b/src/objc/pop/MCOPOPSession.mm
@@ -71,7 +71,7 @@ private:
     return MCO_OBJC_BRIDGE_GET(description);
 }
 
-- (id)init {
+- (instancetype) init {
     self = [super init];
     
     _session = new mailcore::POPAsyncSession();

--- a/src/objc/provider/MCOAccountValidator.mm
+++ b/src/objc/provider/MCOAccountValidator.mm
@@ -71,7 +71,7 @@ MCO_OBJC_SYNTHESIZE_BOOL(setImapEnabled, isImapEnabled)
 MCO_OBJC_SYNTHESIZE_BOOL(setPopEnabled, isPopEnabled)
 MCO_OBJC_SYNTHESIZE_BOOL(setSmtpEnabled, isSmtpEnabled)
 
-- (id) init
+- (instancetype) init
 {
     mailcore::AccountValidator * validator = new mailcore::AccountValidator();
     self = [self initWithMCValidator:validator];
@@ -79,7 +79,7 @@ MCO_OBJC_SYNTHESIZE_BOOL(setSmtpEnabled, isSmtpEnabled)
     return self;
 }
 
-- (id) initWithMCValidator:(mailcore::AccountValidator *)validator
+- (instancetype) initWithMCValidator:(mailcore::AccountValidator *)validator
 {
     self = [super initWithMCOperation:validator];
     

--- a/src/objc/provider/MCOMailProvider.h
+++ b/src/objc/provider/MCOMailProvider.h
@@ -16,7 +16,7 @@
 
 @property (nonatomic, copy) NSString * identifier;
 
-- (id) initWithInfo:(NSDictionary *)info;
+- (instancetype) initWithInfo:(NSDictionary *)info;
 
 /**
    A list of ways that you can connect to the IMAP server
@@ -88,6 +88,6 @@
 @interface MCOMailProvider (MCOUnavailable)
 
 /** Do not invoke this directly. */
-- (id) init NS_UNAVAILABLE;
+- (instancetype) init NS_UNAVAILABLE;
 
 @end

--- a/src/objc/provider/MCOMailProvider.mm
+++ b/src/objc/provider/MCOMailProvider.mm
@@ -39,7 +39,7 @@
     return [[[self alloc] initWithMCProvider:provider] autorelease];
 }
 
-- (id) initWithInfo:(NSDictionary *)info
+- (instancetype) initWithInfo:(NSDictionary *)info
 {
     self = [super init];
     
@@ -49,7 +49,7 @@
     return self;
 }
 
-- (id) initWithMCProvider:(mailcore::MailProvider *)provider
+- (instancetype) initWithMCProvider:(mailcore::MailProvider *)provider
 {
     self = [super init];
     

--- a/src/objc/provider/MCOMailProvidersManager.mm
+++ b/src/objc/provider/MCOMailProvidersManager.mm
@@ -26,7 +26,7 @@
     return sharedInstance;
 }
 
-- (id) init
+- (instancetype) init
 {
     NSString * filename;
     

--- a/src/objc/provider/MCONetService.h
+++ b/src/objc/provider/MCONetService.h
@@ -29,7 +29,7 @@
 
 + (MCONetService *) serviceWithInfo:(NSDictionary *)info;
 
-- (id) initWithInfo:(NSDictionary *)info;
+- (instancetype) initWithInfo:(NSDictionary *)info;
 - (NSDictionary *) info;
 
 /** 
@@ -43,6 +43,6 @@
 @interface MCONetService (MCOUnavailable)
 
 /** Do not invoke this directly. */
-- (id) init NS_UNAVAILABLE;
+- (instancetype) init NS_UNAVAILABLE;
 
 @end

--- a/src/objc/provider/MCONetService.mm
+++ b/src/objc/provider/MCONetService.mm
@@ -40,7 +40,7 @@
     return [[[self alloc] initWithInfo:info] autorelease];
 }
 
-- (id) initWithInfo:(NSDictionary *)info
+- (instancetype) initWithInfo:(NSDictionary *)info
 {
     self = [super init];
     
@@ -50,7 +50,7 @@
     return self;
 }
 
-- (id) initWithNetService:(mailcore::NetService *)netService
+- (instancetype) initWithNetService:(mailcore::NetService *)netService
 {
     self = [super init];
     

--- a/src/objc/rfc822/MCOAttachment.mm
+++ b/src/objc/rfc822/MCOAttachment.mm
@@ -31,7 +31,7 @@
     return [[[self alloc] initWithMCPart:attachment] autorelease];
 }
 
-- (id) init
+- (instancetype) init
 {
     mailcore::Attachment * attachment = new mailcore::Attachment();
     self = [super initWithMCPart:attachment];

--- a/src/objc/rfc822/MCOMessageBuilder.mm
+++ b/src/objc/rfc822/MCOMessageBuilder.mm
@@ -22,7 +22,7 @@
     MCORegisterClass(self, &typeid(nativeType));
 }
 
-- (id)init
+- (instancetype) init
 {
     mailcore::MessageBuilder * message = new mailcore::MessageBuilder();
     self = [super initWithMCMessage:message];

--- a/src/objc/rfc822/MCOMessageParser.h
+++ b/src/objc/rfc822/MCOMessageParser.h
@@ -26,7 +26,7 @@
 + (MCOMessageParser *) messageParserWithData:(NSData *)data;
 
 /** data is the RFC 822 formatted message.*/
-- (id) initWithData:(NSData *)data;
+- (instancetype) initWithData:(NSData *)data;
 - (void) dealloc;
 
 /** It's the main part of the message. It can be MCOMessagePart, MCOMultipart or MCOAttachment.*/

--- a/src/objc/rfc822/MCOMessageParser.mm
+++ b/src/objc/rfc822/MCOMessageParser.mm
@@ -36,7 +36,7 @@
     return [[[MCOMessageParser alloc] initWithData:data] autorelease];
 }
 
-- (id) initWithData:(NSData *)data
+- (instancetype) initWithData:(NSData *)data
 {
     mailcore::MessageParser * message = new mailcore::MessageParser((CFDataRef) data);
     self = [super initWithMCMessage:message];

--- a/src/objc/smtp/MCOSMTPSendOperation.mm
+++ b/src/objc/smtp/MCOSMTPSendOperation.mm
@@ -61,7 +61,7 @@ private:
     return [[[self alloc] initWithMCOperation:op] autorelease];
 }
 
-- (id) initWithMCOperation:(mailcore::Operation *)op
+- (instancetype) initWithMCOperation:(mailcore::Operation *)op
 {
     self = [super initWithMCOperation:op];
     

--- a/src/objc/smtp/MCOSMTPSession.mm
+++ b/src/objc/smtp/MCOSMTPSession.mm
@@ -69,7 +69,7 @@ private:
     return _session;
 }
 
-- (id)init {
+- (instancetype) init {
     self = [super init];
     
     _session = new mailcore::SMTPAsyncSession();

--- a/src/objc/utils/MCOIndexSet+Private.h
+++ b/src/objc/utils/MCOIndexSet+Private.h
@@ -13,7 +13,7 @@
 #ifdef __cplusplus
 @interface MCOIndexSet (Private)
 
-- (id) initWithMCIndexSet:(mailcore::IndexSet *)indexSet;
+- (instancetype) initWithMCIndexSet:(mailcore::IndexSet *)indexSet;
 
 @end
 #endif

--- a/src/objc/utils/MCOIndexSet.mm
+++ b/src/objc/utils/MCOIndexSet.mm
@@ -44,7 +44,7 @@ MCO_SYNTHESIZE_NSCODING
     return _indexSet;
 }
 
-- (id) init
+- (instancetype) init
 {
     mailcore::IndexSet * indexSet = new mailcore::IndexSet();
     self = [self initWithMCIndexSet:indexSet];
@@ -52,7 +52,7 @@ MCO_SYNTHESIZE_NSCODING
     return self;
 }
 
-- (id) initWithMCIndexSet:(mailcore::IndexSet *)indexSet
+- (instancetype) initWithMCIndexSet:(mailcore::IndexSet *)indexSet
 {
     self = [super init];
     _indexSet = indexSet;

--- a/src/objc/utils/MCOOperation+Private.h
+++ b/src/objc/utils/MCOOperation+Private.h
@@ -20,7 +20,7 @@ namespace mailcore {
 
 @interface MCOOperation (Private)
 #ifdef __cplusplus
-- (id) initWithMCOperation:(mailcore::Operation *)op;
+- (instancetype) initWithMCOperation:(mailcore::Operation *)op;
 #endif
 - (void) start;
 @end

--- a/src/objc/utils/MCOOperation.mm
+++ b/src/objc/utils/MCOOperation.mm
@@ -56,7 +56,7 @@ public:
     return _operation;
 }
 
-- (id) initWithMCOperation:(Operation *)op
+- (instancetype) initWithMCOperation:(Operation *)op
 {
     self = [super init];
     

--- a/src/objc/utils/NSObject+MCO.h
+++ b/src/objc/utils/NSObject+MCO.h
@@ -79,7 +79,7 @@ MCO_NATIVE_INSTANCE->setter((mcType) getter); \
 }
 
 #define MCO_SYNTHESIZE_NSCODING \
-- (id) initWithCoder:(NSCoder *)coder \
+- (instancetype) initWithCoder:(NSCoder *)coder \
 { \
   mailcore::HashMap * serializable = MCO_FROM_OBJC(mailcore::HashMap, [coder decodeObjectForKey:@"info"]); \
   self = MCO_TO_OBJC(mailcore::Object::objectWithSerializable(serializable)); \


### PR DESCRIPTION
- Uses `instancetype` over `id` where possible