### PR TITLE
MCIMAPCapabilityOperation takes into account cached capabilities values

### DIFF
--- a/src/async/imap/MCIMAPCapabilityOperation.cpp
+++ b/src/async/imap/MCIMAPCapabilityOperation.cpp
@@ -30,13 +30,16 @@ IndexSet * IMAPCapabilityOperation::capabilities()
 
 void IMAPCapabilityOperation::main()
 {
-    ErrorCode error;
-    session()->session()->loginIfNeeded(&error);
-    if (error != ErrorNone) {
-        setError(error);
-        return;
+    ErrorCode error = ErrorNone;
+    mCapabilities = session()->session()->storedCapabilities();
+    if (mCapabilities == NULL) {
+        session()->session()->loginIfNeeded(&error);
+        if (error != ErrorNone) {
+            setError(error);
+            return;
+        }
+        mCapabilities = session()->session()->capability(&error);
     }
-    mCapabilities = session()->session()->capability(&error);
     MC_SAFE_RETAIN(mCapabilities);
     setError(error);
 }

--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -3749,6 +3749,18 @@ void IMAPSession::capabilitySetWithSessionState(IndexSet * capabilities)
     applyCapabilities(capabilities);
 }
 
+IndexSet * IMAPSession::storedCapabilities() {
+    if (mImap == NULL ||
+        mImap->imap_connection_info == NULL ||
+        mImap->imap_connection_info->imap_capability == NULL) {
+        return NULL;
+    }
+    IndexSet *result = new IndexSet();
+    capabilitySetWithSessionState(result);
+    result->autorelease();
+    return result;
+}
+
 void IMAPSession::applyCapabilities(IndexSet * capabilities)
 {
     if (capabilities->containsIndex(IMAPCapabilityId)) {

--- a/src/core/imap/MCIMAPSession.h
+++ b/src/core/imap/MCIMAPSession.h
@@ -177,8 +177,6 @@ namespace mailcore {
         virtual bool isNamespaceEnabled();
         virtual bool isCompressionEnabled();
         virtual bool allowsNewPermanentFlags();
-        
-        virtual IndexSet * storedCapabilities();
       
         virtual String * gmailUserDisplayName() DEPRECATED_ATTRIBUTE;
         
@@ -212,6 +210,7 @@ namespace mailcore {
         virtual bool isAutomaticConfigurationDone();
         virtual void resetAutomaticConfigurationDone();
         virtual void applyCapabilities(IndexSet * capabilities);
+        virtual IndexSet * storedCapabilities();
         
     private:
         String * mHostname;

--- a/src/core/imap/MCIMAPSession.h
+++ b/src/core/imap/MCIMAPSession.h
@@ -176,7 +176,9 @@ namespace mailcore {
         virtual bool isXOAuthEnabled();
         virtual bool isNamespaceEnabled();
         virtual bool isCompressionEnabled();
-        virtual bool allowsNewPermanentFlags(); 
+        virtual bool allowsNewPermanentFlags();
+        
+        virtual IndexSet * storedCapabilities();
       
         virtual String * gmailUserDisplayName() DEPRECATED_ATTRIBUTE;
         


### PR DESCRIPTION
MCIMAPCapabilityOperation can return cached capabilities in order to minimize the number of extra imap capabilities network requests