### PR TITLE
Added suggested linker flags to cocoapods-section

### DIFF
--- a/build-mac/README.md
+++ b/build-mac/README.md
@@ -25,6 +25,11 @@ pod 'mailcore2-ios'
 pod 'mailcore2-osx'
 ```
 
+**Further Steps**
+
+You may also need to add `-lresolv` to your application-target -> `Build Settings` -> `Other Linker Flags`.
+
+
 ### Binary ###
 
 **For iOS:**


### PR DESCRIPTION
Added further steps to Cocoapods-section to solve `Undefined symbols for arm64` build-error. To prevent this from happening `-lresolv` needs to be added to the `Other Linker Flags`.
Related issue: #1352 