### PR TITLE
Added ability to customize the identity of IMAP client in the time of…

### DIFF
--- a/src/async/imap/MCIMAPAsyncSession.cpp
+++ b/src/async/imap/MCIMAPAsyncSession.cpp
@@ -236,6 +236,11 @@ IMAPIdentity * IMAPAsyncSession::clientIdentity()
     return mClientIdentity;
 }
 
+void IMAPAsyncSession::setClientIdentity(IMAPIdentity * clientIdentity)
+{
+    MC_SAFE_REPLACE_COPY(IMAPIdentity, mClientIdentity, clientIdentity);
+}
+
 String * IMAPAsyncSession::gmailUserDisplayName()
 {
     return mGmailUserDisplayName;

--- a/src/async/imap/MCIMAPAsyncSession.h
+++ b/src/async/imap/MCIMAPAsyncSession.h
@@ -104,6 +104,8 @@ namespace mailcore {
         
         virtual IMAPIdentity * serverIdentity();
         virtual IMAPIdentity * clientIdentity();
+        virtual void setClientIdentity(IMAPIdentity * clientIdentity);
+
         virtual String * gmailUserDisplayName() DEPRECATED_ATTRIBUTE;
         
         virtual IMAPFolderInfoOperation * folderInfoOperation(String * folder);

--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -3412,6 +3412,11 @@ IMAPIdentity * IMAPSession::clientIdentity()
     return mClientIdentity;
 }
 
+void IMAPSession::setClientIdentity(IMAPIdentity * identity)
+{
+    MC_SAFE_REPLACE_COPY(IMAPIdentity, mClientIdentity, identity);
+}
+
 HashMap * IMAPSession::fetchNamespace(ErrorCode * pError)
 {
     HashMap * result;

--- a/src/core/imap/MCIMAPSession.h
+++ b/src/core/imap/MCIMAPSession.h
@@ -65,7 +65,8 @@ namespace mailcore {
         
         virtual IMAPIdentity * serverIdentity();
         virtual IMAPIdentity * clientIdentity();
-        
+        virtual void setClientIdentity(IMAPIdentity * identity);
+
         virtual void select(String * folder, ErrorCode * pError);
         virtual IMAPFolderStatus * folderStatus(String * folder, ErrorCode * pError);
         

--- a/src/objc/imap/MCOIMAPSession.h
+++ b/src/objc/imap/MCOIMAPSession.h
@@ -87,7 +87,7 @@
 @property (nonatomic, strong) MCOIMAPNamespace * defaultNamespace;
 
 /** The identity of the IMAP client. */
-@property (nonatomic, strong, readonly) MCOIMAPIdentity * clientIdentity;
+@property (nonatomic, copy) MCOIMAPIdentity * clientIdentity;
 
 /** The identity of the IMAP server. */
 @property (nonatomic, strong, readonly) MCOIMAPIdentity * serverIdentity;

--- a/src/objc/imap/MCOIMAPSession.mm
+++ b/src/objc/imap/MCOIMAPSession.mm
@@ -122,6 +122,11 @@ MCO_OBJC_SYNTHESIZE_SCALAR(dispatch_queue_t, dispatch_queue_t, setDispatchQueue,
     return MCO_OBJC_BRIDGE_GET(clientIdentity);
 }
 
+- (void) setClientIdentity:(MCOIMAPIdentity *)clientIdentity
+{
+    MCO_OBJC_BRIDGE_SET(setClientIdentity, IMAPIdentity, clientIdentity);
+}
+
 - (MCOIMAPIdentity *) serverIdentity
 {
     return MCO_OBJC_BRIDGE_GET(serverIdentity);


### PR DESCRIPTION
… session initialization.

The Mailcore2 will use it in loginIfNeeded() instead of sending "1 ID NIL".