### PR TITLE
Move inttypes include within ifdef __cplusplus in MCIndexSet.h

### DIFF
--- a/src/core/basetypes/MCIndexSet.h
+++ b/src/core/basetypes/MCIndexSet.h
@@ -12,9 +12,10 @@
 
 #include <MailCore/MCObject.h>
 #include <MailCore/MCRange.h>
-#include <inttypes.h>
 
 #ifdef __cplusplus
+
+#include <inttypes.h>
 
 namespace mailcore {
     


### PR DESCRIPTION
This fixes a "include of non-modular header inside framework" error that appears in Xcode 7.3 and later