### PR TITLE
Remove duplicate `mCanIdle`

### DIFF
--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -3916,7 +3916,9 @@ void IMAPSession::applyCapabilities(IndexSet * capabilities)
         mIsGmail = true;
     }
     if (capabilities->containsIndex(IMAPCapabilityIdle)) {
+        LOCK();
         mIdleEnabled = true;
+        UNLOCK();
     }
     if (capabilities->containsIndex(IMAPCapabilityCondstore)) {
         mCondstoreEnabled = true;
@@ -3940,7 +3942,10 @@ void IMAPSession::applyCapabilities(IndexSet * capabilities)
 
 bool IMAPSession::isIdleEnabled()
 {
-    return mIdleEnabled;
+    LOCK();
+    bool idleEnabled = mIdleEnabled;
+    UNLOCK();
+    return idleEnabled;
 }
 
 bool IMAPSession::isXListEnabled()

--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -3851,9 +3851,7 @@ void IMAPSession::capabilitySetWithSessionState(IndexSet * capabilities)
         capabilities->addIndex(IMAPCapabilityAuthLogin);
     }
     if (mailimap_has_idle(mImap)) {
-        LOCK();
-        mIdleEnabled = true;
-        UNLOCK();
+        capabilities->addIndex(IMAPCapabilityIdle);
     }
     if (mailimap_has_id(mImap)) {
         capabilities->addIndex(IMAPCapabilityId);
@@ -3865,9 +3863,6 @@ void IMAPSession::capabilitySetWithSessionState(IndexSet * capabilities)
         // Disable use of XLIST if this is the Gmail IMAP server because it implements
         // RFC 6154.
         capabilities->addIndex(IMAPCapabilityGmail);
-    }
-    if (mailimap_has_idle(mImap)) {
-        capabilities->addIndex(IMAPCapabilityIdle);
     }
     if (mailimap_has_condstore(mImap)) {
         capabilities->addIndex(IMAPCapabilityCondstore);

--- a/src/core/imap/MCIMAPSession.h
+++ b/src/core/imap/MCIMAPSession.h
@@ -263,7 +263,6 @@ namespace mailcore {
         unsigned int mLastFetchedSequenceNumber;
         String * mCurrentFolder;
         pthread_mutex_t mIdleLock;
-        bool mCanIdle;
         int mState;
         mailimap * mImap;
         IMAPProgressCallback * mProgressCallback;


### PR DESCRIPTION
#1145 raised an interesting point.  I think at one point `mCanIdle` was supposed to stand for a client-side value for the IDLE capability while `mIdleEnabled` was supposed to represent the server-side capability, but somewhere along the way `mCanIdle`'s role got reduced to what it does now which is essentially shadow `mIdleEnabled`.  Far as I can tell this won't have an impact on the semantics of the code and may actually clarify the implementation of `isIdleEnabled()`.