### PR TITLE
Handle case with parsing parts info with non-empty content name and e…

### DIFF
--- a/src/core/abstract/MCAbstractPart.cpp
+++ b/src/core/abstract/MCAbstractPart.cpp
@@ -260,7 +260,10 @@ void AbstractPart::importIMAPFields(struct mailimap_body_fields * fields,
                     imap_param = (struct mailimap_single_body_fld_param *) clist_content(cur);
                     
                     if (strcasecmp(imap_param->pa_name, "filename") == 0) {
-                        setFilename(String::stringByDecodingMIMEHeaderValue(imap_param->pa_value));
+                        String * filename = String::stringByDecodingMIMEHeaderValue(imap_param->pa_value);
+                        if (filename != NULL && filename->length() > 0) {
+                            setFilename(filename);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
…mpty non-null attachment filename.

BODYSTRUCTURE ((("text" "plain" ("charset" "utf-8") NIL NIL "base64" 58 1 NIL NIL NIL NIL)("text" "html" ("charset" "utf-8") NIL NIL "base64" 112 2 NIL NIL NIL NIL) "alternative" ("boundary" "--ALT--tVxePtRpLBZY6Hs0ao1c7BSGQcoQy5ur1460647449") NIL NIL NIL)("video" "quicktime" ("name" "=?UTF-8?B?Mi5tb3Y=?=") NIL NIL "base64" 3722950 NIL ("attachment" ("filename" "")) NIL NIL)("video" "quicktime" ("name" "=?UTF-8?B?MS5tb3Y=?=") NIL NIL "base64" 3941584 NIL ("attachment" ("filename" "")) NIL NIL)("video" "quicktime" ("name" "=?UTF-8?B?My5tb3Y=?=") NIL NIL "base64" 15571848 NIL ("attachment" ("filename" "")) NIL NIL) "mixed" ("boundary" "----tVxePtRpLBZY6Hs0ao1c7BSGQcoQy5ur-lcGxoWOFOYrZWofU-1460647449") NIL NIL NIL)