### PR TITLE
Updating trash folder path for Outlook

### DIFF
--- a/resources/providers.json
+++ b/resources/providers.json
@@ -1004,7 +1004,7 @@
             "allmail":"Archive",
             "spam":"Junk",
             "sentmail":"Sent Messages",
-            "trash":"Deleted Messages"
+            "trash":"Deleted”
         }
     },
      "qq": {


### PR DESCRIPTION
I just created a new Outlook account, and the IMAP folder path for trash is "Deleted".  Not sure if this is the case for all outlook and hotmail accounts, so it might make sense to get a more general consolidation on this.