### PR TITLE
Prevent demo crash in _convertToJPEGData when image data cannot be converted

### DIFF
--- a/example/ios/iOS UI Test/iOS UI Test/MCTMsgViewController.mm
+++ b/example/ios/iOS UI Test/iOS UI Test/MCTMsgViewController.mm
@@ -254,38 +254,27 @@ typedef void (^DownloadCallback)(NSError * error);
     [info setObject:(id) [NSNumber numberWithFloat:(float) IMAGE_PREVIEW_WIDTH] forKey:(__bridge id) kCGImageSourceThumbnailMaxPixelSize];
     thumbnail = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, (__bridge CFDictionaryRef) info);
 
-    CGImageDestinationRef destination;
-    NSMutableData * destData = [NSMutableData data];
-
-    if (destData != nil) {
+    if (thumbnail != nil) {
+        
+        CGImageDestinationRef destination;
+        NSMutableData * destData = [NSMutableData data];
         destination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef) destData,
                                                        (CFStringRef) @"public.jpeg",
                                                        1, NULL);
-        if ((destination != NULL) && (thumbnail != NULL)) {
-            CGImageDestinationAddImage(destination, thumbnail, NULL);
-        }
-        if (destination != NULL) {
-            CGImageDestinationFinalize(destination);
-        }
-    } else {
-        destination = NULL;
-    }
-
-    if (destination != NULL) {
+        
+        CGImageDestinationAddImage(destination, thumbnail, NULL);
+        CGImageDestinationFinalize(destination);
+        
         CFRelease(destination);
-    }
-    if (thumbnail != NULL) {
+        
         CFRelease(thumbnail);
-    }
-    if (imageSource != NULL) {
         CFRelease(imageSource);
-    }
-
-    if ((destData != NULL) && (thumbnail != NULL) && (destination != NULL)) {
+        
         return destData;
     } else {
         return nil;
     }
+    
 }
 
 @end

--- a/example/ios/iOS UI Test/iOS UI Test/MCTMsgViewController.mm
+++ b/example/ios/iOS UI Test/iOS UI Test/MCTMsgViewController.mm
@@ -257,19 +257,35 @@ typedef void (^DownloadCallback)(NSError * error);
     CGImageDestinationRef destination;
     NSMutableData * destData = [NSMutableData data];
 
-    destination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef) destData,
-                                                   (CFStringRef) @"public.jpeg",
-                                                   1, NULL);
-    
-    CGImageDestinationAddImage(destination, thumbnail, NULL);
-    CGImageDestinationFinalize(destination);
+    if (destData != nil) {
+        destination = CGImageDestinationCreateWithData((__bridge CFMutableDataRef) destData,
+                                                       (CFStringRef) @"public.jpeg",
+                                                       1, NULL);
+        if ((destination != NULL) && (thumbnail != NULL)) {
+            CGImageDestinationAddImage(destination, thumbnail, NULL);
+        }
+        if (destination != NULL) {
+            CGImageDestinationFinalize(destination);
+        }
+    } else {
+        destination = NULL;
+    }
 
-    CFRelease(destination);
+    if (destination != NULL) {
+        CFRelease(destination);
+    }
+    if (thumbnail != NULL) {
+        CFRelease(thumbnail);
+    }
+    if (imageSource != NULL) {
+        CFRelease(imageSource);
+    }
 
-    CFRelease(thumbnail);
-    CFRelease(imageSource);
-
-    return destData;
+    if ((destData != NULL) && (thumbnail != NULL) && (destination != NULL)) {
+        return destData;
+    } else {
+        return nil;
+    }
 }
 
 @end


### PR DESCRIPTION
If a message contains images where the data is not a valid image, the demo crashes. These changes prevent the crash.

One source of such messages is from old Mac mail clients which include both image data and resource forks as two separate images in emails.