### PR TITLE
MCSMTPSession.cpp: outlook bcc fix

### DIFF
--- a/src/core/smtp/MCSMTPSession.cpp
+++ b/src/core/smtp/MCSMTPSession.cpp
@@ -709,7 +709,7 @@ void SMTPSession::internalSendMessage(Address * from, Array * recipients, Data *
         return;
     }
     
-    if (!this->mOutlook) {
+    if (!this->mOutlookServer) {
         messageData = dataWithFilteredBcc(messageData);
     }
 

--- a/src/core/smtp/MCSMTPSession.cpp
+++ b/src/core/smtp/MCSMTPSession.cpp
@@ -709,7 +709,9 @@ void SMTPSession::internalSendMessage(Address * from, Array * recipients, Data *
         return;
     }
     
-    messageData = dataWithFilteredBcc(messageData);
+    if (!this->mOutlook) {
+        messageData = dataWithFilteredBcc(messageData);
+    }
 
     mProgressCallback = callback;
     bodyProgress(0, messageData->length());


### PR DESCRIPTION
I've discovered that outlook.com requires presence of "bcc" field in rfc822 data blob. Otherwise message won't be delivered to bcc recipients without any notice from server.