### PR TITLE
MCSMTPSession.cpp: outlook bcc fix (continued)

### DIFF
--- a/src/core/smtp/MCSMTPSession.cpp
+++ b/src/core/smtp/MCSMTPSession.cpp
@@ -709,7 +709,7 @@ void SMTPSession::internalSendMessage(Address * from, Array * recipients, Data *
         return;
     }
     
-    if (!this->mOutlook) {
+    if (!this->mOutlookServer) {
         messageData = dataWithFilteredBcc(messageData);
     }
 

--- a/src/core/smtp/MCSMTPSession.cpp
+++ b/src/core/smtp/MCSMTPSession.cpp
@@ -709,7 +709,9 @@ void SMTPSession::internalSendMessage(Address * from, Array * recipients, Data *
         return;
     }
     
-    messageData = dataWithFilteredBcc(messageData);
+    if (!this->mOutlook) {
+        messageData = dataWithFilteredBcc(messageData);
+    }
 
     mProgressCallback = callback;
     bodyProgress(0, messageData->length());

--- a/src/core/smtp/MCSMTPSession.cpp
+++ b/src/core/smtp/MCSMTPSession.cpp
@@ -78,10 +78,11 @@ void SMTPSession::setHostname(String * hostname)
 {
     MC_SAFE_REPLACE_COPY(String, mHostname, hostname);
     
-    if (hostname != NULL) {
-        if (hostname->lowercaseString()->isEqual(MCSTR("smtp-mail.outlook.com"))) {
-            mOutlookServer = true;
-        }
+    if (hostname != NULL && hostname->lowercaseString()->isEqual(MCSTR("smtp-mail.outlook.com"))) {
+        mOutlookServer = true;
+    }
+    else {
+        mOutlookServer = false;
     }
 }
 

--- a/src/core/smtp/MCSMTPSession.cpp
+++ b/src/core/smtp/MCSMTPSession.cpp
@@ -77,6 +77,12 @@ SMTPSession::~SMTPSession()
 void SMTPSession::setHostname(String * hostname)
 {
     MC_SAFE_REPLACE_COPY(String, mHostname, hostname);
+    
+    if (hostname != NULL) {
+        if (hostname->lowercaseString()->isEqual(MCSTR("smtp-mail.outlook.com"))) {
+            mOutlookServer = true;
+        }
+    }
 }
 
 String * SMTPSession::hostname()
@@ -288,12 +294,6 @@ void SMTPSession::connect(ErrorCode * pError)
     int r;
     
     setup();
-
-    if (hostname() != NULL) {
-        if (hostname()->lowercaseString()->isEqual(MCSTR("smtp-mail.outlook.com"))) {
-            mOutlookServer = true;
-        }
-    }
 
     switch (mConnectionType) {
         case ConnectionTypeStartTLS:


### PR DESCRIPTION
My apologizes for undiscovered bug.
Actual assignment to mOutlookServer (based on host name) occured after making decision on bcc wiping. When default value of mOutlookServer was true I didn't notice this misbehaviour.