### PR TITLE
MCIMAPCheckAccountOperation: connectIfNeeded() then login() sequence …

### DIFF
--- a/src/async/imap/MCIMAPCheckAccountOperation.cpp
+++ b/src/async/imap/MCIMAPCheckAccountOperation.cpp
@@ -28,13 +28,10 @@ IMAPCheckAccountOperation::~IMAPCheckAccountOperation()
 void IMAPCheckAccountOperation::main()
 {
     ErrorCode error;
-    session()->session()->connectIfNeeded(&error);
-    if (error == ErrorNone) {
-        session()->session()->login(&error);
-        if (error != ErrorNone) {
-            MC_SAFE_REPLACE_COPY(String, mLoginResponse, session()->session()->loginResponse());
-            MC_SAFE_REPLACE_COPY(Data, mLoginUnparsedResponseData, session()->session()->unparsedResponseData());
-        }
+    session()->session()->loginIfNeeded(&error);
+    if (error != ErrorNone) {
+        MC_SAFE_REPLACE_COPY(String, mLoginResponse, session()->session()->loginResponse());
+        MC_SAFE_REPLACE_COPY(Data, mLoginUnparsedResponseData, session()->session()->unparsedResponseData());
     }
     setError(error);
 }


### PR DESCRIPTION
It's dangerous to call connectIfNeeded(&error) and then login(&error). If we are already connected and mShouldDisconnect flag is set, then connectIfNeeded() will disconnect and then try to connect again. BUT. The last call to connect can fail, and after that when we try to call login() we'll catch MCAssert(mState == STATE_CONNECTED). Kaboom.

PS. It's rather hard to reproduce this error in real life, one should have unstable error-prone internet connection and issue a reconnect. But we have ~5k remote crash dumps that led us exactly to this place in code.