### PR TITLE
Correct the spelling of CocoaPods in build-mac/README

### DIFF
--- a/build-mac/README.md
+++ b/build-mac/README.md
@@ -11,9 +11,9 @@ Here you can find [Instructions for install Carthage](https://github.com/Carthag
 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
-### Cocoapods ###
+### CocoaPods ###
 
-MailCore 2 is available on [Cocoapods](http://cocoapods.org/).
+MailCore 2 is available on [CocoaPods](http://cocoapods.org/).
 
 **For iOS:**
 ```


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 