### PR TITLE
Fixed fake 'Auth Error' on iCloud when service responses with 'BAD [UNAVAILABLE] Service temporarily unavailable'

### DIFF
--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -949,6 +949,10 @@ void IMAPSession::login(ErrorCode * pError)
         else if (response->locationOfString(MCSTR("Login to your account via a web browser")) != -1) {
             * pError = ErrorOutlookLoginViaWebBrowser;
         }
+        else if (response->locationOfString(MCSTR("Service temporarily unavailable")) != -1) {
+            mShouldDisconnect = true;
+            * pError = ErrorConnection;
+        }
         else {
             * pError = ErrorAuthentication;
         }


### PR DESCRIPTION
Hi,

I experience an issue with iCloud last few weeks, after Apple forced all users to use app-specific password for IMAP access on iCloud.

Sometimes, Apple server response to client login request with next response:
1 BAD [UNAVAILABLE] Service temporarily unavailable'

Mailcore2 parses this response as 'Auth' error, and our mail client have to ask users to re-login.
I think, in this case we should have 'connection' error.

I've made this pull request to fix this problem.
What do you think about this change? 

Thank You.