### PR TITLE
On Windows, make fopen use provided `mode`

### DIFF
--- a/src/core/basetypes/MCWin32.cpp
+++ b/src/core/basetypes/MCWin32.cpp
@@ -3,7 +3,7 @@
 FILE * mailcore::win32_fopen(const char * filename, const char * mode)
 {
     FILE * f = NULL;
-    int r = fopen_s(&f, filename, "rb");
+    int r = fopen_s(&f, filename, mode);
     if (r != 0) {
         return NULL;
     }


### PR DESCRIPTION
This took a while to track down—calling `data->writeToFile(&mfilepath)` or a similar method on windows does not work because the overridden version of `fopen` does not look at the provided `mode` and will not create files!