### PR TITLE
Fix calendar attachment appearing twice in the HTML output

### DIFF
--- a/src/core/renderer/MCHTMLRenderer.cpp
+++ b/src/core/renderer/MCHTMLRenderer.cpp
@@ -474,7 +474,7 @@ String * htmlForAbstractMultipartAlternative(AbstractMultipart * part, htmlRende
     
     String * result = String::string();
     result->appendString(html);
-    if (calendar != NULL) {
+    if (calendar != NULL && calendar != preferredAlternative) {
         result->appendString(htmlForAbstractPart(calendar, context));
     }
     return result;


### PR DESCRIPTION
Bug:
Calendar attachment was appearing twice in the HTML body.

Reason:
If `preferredAlternative` was equal to `calendar`, we were adding output of `htmlForAbstractPart()` for the same `AbstractPart` twice to the `result` variable.