### PR TITLE
On non-Apple systems, clean up MCObject locks

### DIFF
--- a/src/core/basetypes/MCObject.cpp
+++ b/src/core/basetypes/MCObject.cpp
@@ -33,6 +33,9 @@ Object::Object()
 
 Object::~Object()
 {
+#ifndef __APPLE__
+    pthread_mutex_destroy(&mLock);
+#endif
 }
 
 void Object::init()


### PR DESCRIPTION
On Windows, Mailspring was leaking a huge number of event handles, which could cause it to eventually crash. Adding this line doesn't cause the code to crash and reduces the number of handles reported by Process Explorer.