### PR TITLE
Move unavailable initializers out of categories, so they’ll be proper…

### DIFF
--- a/src/objc/abstract/MCOAbstractPart.h
+++ b/src/objc/abstract/MCOAbstractPart.h
@@ -107,10 +107,7 @@ namespace mailcore {
 /** Returns an array with the names of all content type parameters.*/
 - (NSArray * /* NSString */) allContentTypeParametersNames;
 
-@end
-
-@interface MCOAbstractPart (MCOUnavailable)
-
+#pragma mark - Unavailable initializers
 /** Do not invoke this directly. */
 - (instancetype) init NS_UNAVAILABLE;
 /** Do not invoke this directly. */

--- a/src/objc/provider/MCOMailProvider.h
+++ b/src/objc/provider/MCOMailProvider.h
@@ -83,10 +83,7 @@
 */
 - (NSString *) importantFolderPath;
 
-@end
-
-@interface MCOMailProvider (MCOUnavailable)
-
+#pragma mark - Unavailable initializers
 /** Do not invoke this directly. */
 - (instancetype) init NS_UNAVAILABLE;
 /** Do not invoke this directly. */

--- a/src/objc/provider/MCONetService.h
+++ b/src/objc/provider/MCONetService.h
@@ -38,10 +38,7 @@
 */
 - (NSString *) hostnameWithEmail:(NSString *)email;
 
-@end
-
-@interface MCONetService (MCOUnavailable)
-
+#pragma mark - Unavailable initializers
 /** Do not invoke this directly. */
 - (instancetype) init NS_UNAVAILABLE;
 /** Do not invoke this directly. */

--- a/src/objc/utils/MCOOperation.h
+++ b/src/objc/utils/MCOOperation.h
@@ -36,10 +36,7 @@
 /** Cancel the operation.*/
 - (void) cancel;
 
-@end
-
-@interface MCOOperation (MCOUnavailable)
-
+#pragma mark - Unavailable initializers
 /** Do not invoke this directly. */
 - (instancetype) init NS_UNAVAILABLE;
 /** Do not invoke this directly. */


### PR DESCRIPTION
If NS_UNAVAILABLE is used in a category, Swift doesn’t notice, and these initializers are permitted even though they don’t work. This PR moves the unavailable initializers from categories into class headers, so that the initializers will be correctly unavailable when using Swift.

Thanks to Daniel Jalkut for helping figure this out!