### PR TITLE
Fix crash when connection's owner is NULL

### DIFF
--- a/src/async/imap/MCIMAPAsyncConnection.cpp
+++ b/src/async/imap/MCIMAPAsyncConnection.cpp
@@ -57,14 +57,18 @@ namespace mailcore {
 
         virtual void queueStartRunning() {
             mConnection->setQueueRunning(true);
-            mConnection->owner()->operationRunningStateChanged();
+            if (mConnection->owner()) {
+                mConnection->owner()->operationRunningStateChanged();
+            }
             mConnection->queueStartRunning();
         }
 
         virtual void queueStoppedRunning() {
             mConnection->setQueueRunning(false);
             mConnection->tryAutomaticDisconnect();
-            mConnection->owner()->operationRunningStateChanged();
+            if (mConnection->owner()) {
+                mConnection->owner()->operationRunningStateChanged();
+            }
             mConnection->queueStoppedRunning();
         }
 


### PR DESCRIPTION
H!. I've been observing a crash caused by `mConnection->owner()` being `NULL` in `queueStartRunning()`. I wasn't able to reproduce or even isolate it, though. It happens sporadically, in about 0.1% of all sessions.

We create a new session (and deallocate the old one) when a reachability status changes. My understanding is that in this case `IMAPAsyncSession` instance gets deallocated but `IMAPAsyncConnection` is still alive. Should this situation be even possible from the memory-management POV? I see that `IMAPAsyncConnection` retains `mOwner`, so I would assume that `IMAPAsyncSession` instance would always outlive the connection. Is there a better fix than what I propose?

Stack trace from Crashlytics:
<img width="965" alt="screen shot 2018-02-13 at 13 05 11" src="https://user-images.githubusercontent.com/197767/36149056-93d8a044-10be-11e8-96de-5c2dac1a73f8.png">
