### PR TITLE
Fix Xcode warning

### DIFF
--- a/src/async/imap/MCIMAPAsyncSession.h
+++ b/src/async/imap/MCIMAPAsyncSession.h
@@ -226,7 +226,7 @@ namespace mailcore {
         virtual IMAPAsyncConnection * matchingSessionForFolder(String * folder);
         /*! Returns a session with minimum operation queue among already created ones.
          If @param filterByFolder is true, then function filters sessions with
-         predicate (lastFolder() EQUALS TO @param folder). In case of @param folder is NULL
+         predicate ( lastFolder() EQUALS TO @param folder ). In case of param folder is NULL
          the function would search a session among non-selected ones. */
         virtual IMAPAsyncConnection * sessionWithMinQueue(bool filterByFolder, String * folder);
         /*! Returns existant or new session with empty operation queue, if it can.


### PR DESCRIPTION
It reports that it can’t find `folder)` parameter in declaration.