### PR TITLE
Fix message partID ('message/rfc822' attachments)

### DIFF
--- a/src/core/imap/MCIMAPPart.cpp
+++ b/src/core/imap/MCIMAPPart.cpp
@@ -154,7 +154,7 @@ IMAPMessagePart * IMAPPart::attachmentWithIMAPBody1PartMessage(struct mailimap_b
     nextPartID = NULL;
     if (message->bd_body->bd_type == MAILIMAP_BODY_1PART) {
         // msg or 1part
-        nextPartID = partID->stringByAppendingUTF8Format(".1");
+        nextPartID = partID;
     }
     else if (message->bd_body->bd_type == MAILIMAP_BODY_MPART) {
         // mpart

--- a/src/core/rfc822/MCMessageParser.cpp
+++ b/src/core/rfc822/MCMessageParser.cpp
@@ -277,7 +277,7 @@ void MessageParser::recursiveSetupPartIDWithMessagePart(mailcore::MessagePart * 
                 partID = MCSTR("1");
             }
             else {
-                partID = partIDPrefix->stringByAppendingUTF8Characters(".1");
+                partID = partIDPrefix;
             }
             break;
         }


### PR DESCRIPTION
Message part with headers 'Content-Disposition: attachment;', 'Content-Type: message/rfc822;' can't be fetched from the Google IMAP server.

Bug is caused by a unnecessary suffix ".1", which is added by IMAPPart::attachmentWithIMAPBody1PartMessage and by MessageParser::recursiveSetupPartIDWithMessagePart for a 'MessagePart' parts.

Test message in the attachment.
[anonymized_message.mbox.zip](https://github.com/MailCore/mailcore2/files/2114813/anonymized_message.mbox.zip)
