### PR TITLE
Eliminate -Wimplicit-fallthrough trigger

### DIFF
--- a/src/core/nntp/MCNNTPSession.cpp
+++ b/src/core/nntp/MCNNTPSession.cpp
@@ -840,6 +840,7 @@ static int xover_resp_to_fields(struct newsnntp_xover_resp_item * item, struct m
                     r = MAIL_ERROR_MEMORY;
                     goto free_list;
                 }
+                break
 
             case MAILIMF_ERROR_PARSE:
                 break;


### PR DESCRIPTION
Insert a no-op `break`, preventing -Wimplicit-fallthrough from triggering.