### PR TITLE
Update podspec to point to a release that exists.

### DIFF
--- a/mailcore2-ios.podspec.json
+++ b/mailcore2-ios.podspec.json
@@ -1,9 +1,9 @@
 {
   "name": "mailcore2-ios",
-  "version": "0.6.4",
+  "version": "0.6.3",
   "summary": "Mailcore 2 for iOS",
   "description": "MailCore 2 provide a simple and asynchronous API to work with e-mail protocols IMAP, POP and SMTP.",
-  "homepage": "http://libmailcore.com",
+  "homepage": "https://github.com/MailCore/mailcore2",
   "license": {
     "type": "BSD",
     "file": "LICENSE"

--- a/mailcore2-osx.podspec.json
+++ b/mailcore2-osx.podspec.json
@@ -1,9 +1,9 @@
 {
   "name": "mailcore2-osx",
-  "version": "0.6.4",
+  "version": "0.6.3",
   "summary": "Mailcore 2 for OS X",
   "description": "MailCore 2 provide a simple and asynchronous API to work with e-mail protocols IMAP, POP and SMTP.",
-  "homepage": "http://libmailcore.com",
+  "homepage": "https://github.com/MailCore/mailcore2",
   "license": {
     "type": "BSD",
     "file": "LICENSE"


### PR DESCRIPTION
This changes the Cocoapods setup to point to version 0.6.3 (which exists) instead of version 0.6.4 (which does not exist). It's not clear what version of the source code is included if the podspec says 0.6.4, but it was not current or even recent. This should resolve problems from #1748.
