### PR TITLE
Fix superclass for MCONNTPDisconnectOperation

### DIFF
--- a/src/objc/nntp/MCONNTPDisconnectOperation.h
+++ b/src/objc/nntp/MCONNTPDisconnectOperation.h
@@ -14,7 +14,7 @@
 #import <MailCore/MCONNTPOperation.h>
 
 /* The class is used to perform a disconnect operation. */
-@interface MCONNTPDisconnectOperation : NSObject
+@interface MCONNTPDisconnectOperation : MCONNTPOperation
 
 @end
 


### PR DESCRIPTION
If `MCONNTPDisconnectOperation` inherits from `NSObject`, `MCONNTPDisconnectOperation+mco_objectWithMCObject:` will call a method that doesn’t exist (`-initWithMCOperation:`). Set it to extend MCONNTPOperation instead.