### PR TITLE
Exclude DriverKit SDK from macOS SDK version variable.

### DIFF
--- a/scripts/include.sh/build-dep-cocoapod.sh
+++ b/scripts/include.sh/build-dep-cocoapod.sh
@@ -135,7 +135,7 @@ build_git_ios()
 
 build_git_osx()
 {
-  sdk="`xcodebuild -showsdks 2>/dev/null | grep macosx | sed 's/.*macosx\(.*\)/\1/'`"
+  sdk="`xcodebuild -showsdks 2>/dev/null | grep macosx | grep -v driverkit | sed 's/.*macosx\(.*\)/\1/'`"
   archs="x86_64"
   sdkminversion="10.7"
   

--- a/scripts/include.sh/build-dep.sh
+++ b/scripts/include.sh/build-dep.sh
@@ -155,7 +155,7 @@ build_git_ios()
 
 build_git_osx()
 {
-  sdk="`xcodebuild -showsdks 2>/dev/null | grep macosx | sed 's/.*macosx\(.*\)/\1/'`"
+  sdk="`xcodebuild -showsdks 2>/dev/null | grep macosx | grep -v driverkit | sed 's/.*macosx\(.*\)/\1/'`"
   archs="x86_64"
   sdkminversion="10.7"
   

--- a/scripts/travis/script.sh
+++ b/scripts/travis/script.sh
@@ -2,7 +2,7 @@
 set -e
 
 IOSSDK="`xcodebuild -showsdks 2>/dev/null | grep iphoneos | sed 's/.*iphoneos\(.*\)/\1/'`"
-OSXSDK="`xcodebuild -showsdks 2>/dev/null | grep macosx | sed 's/.*macosx\(.*\)/\1/'`"
+OSXSDK="`xcodebuild -showsdks 2>/dev/null | grep macosx | grep -v driverkit | sed 's/.*macosx\(.*\)/\1/'`"
 IPHONESDK=iphoneos$IOSSDK
 SIMULATORSDK=iphonesimulator$IOSSDK
 MACSDK=macosx$OSXSDK


### PR DESCRIPTION
The DriverKit SDK can appear in the output from `xcodebuild -showsdks`, and as such `macosx19.0` is parsed as a macOS SDK in build scripts, causing them to fail. This change explicitly excludes the DriverKit SDK, which fixed the build script(s) for me.

```
$ xcodebuild -showsdks
<snip>
macOS SDKs:
	DriverKit 19.0                	-sdk driverkit.macosx19.0
	macOS 10.15                   	-sdk macosx10.15
</snip>
```