### PR TITLE
providers.json: Add Hostinger to email providers

### DIFF
--- a/resources/providers.json
+++ b/resources/providers.json
@@ -1401,5 +1401,55 @@
             "sentmail": "Sent Items",
             "trash": "Deleted Items"
         }
+    },
+    "hostinger": {
+        "servers": {
+            "imap": [
+                     {
+                     "port": 993,
+                     "hostname": "imap.hostinger.com",
+                     "ssl": true
+                     },
+                     {
+                     "port": 143,
+                     "hostname": "imap.hostinger.com",
+                     "starttls": true
+                     }
+                     ],
+            "pop": [
+                    {
+                    "port": 995,
+                    "hostname": "pop.hostinger.com",
+                    "ssl": true
+                    },
+                    {
+                    "port": 110,
+                    "hostname": "pop.hostinger.com",
+                    "starttls": true
+                    }
+                    ],
+            "smtp": [
+                     {
+                     "port": 465,
+                     "hostname": "smtp.hostinger.com",
+                     "ssl": true
+                     },
+                     {
+                     "port": 587,
+                     "hostname": "smtp.hostinger.com",
+                     "starttls": true
+                     }
+                     ]
+        },
+        "mx-match": [
+                         "mx[0-9]*\\.hostinger\\.*"
+                         ],
+        "mailboxes": {
+            "allmail": "Archive",
+            "drafts": "Drafts",
+            "spam": "Junk Email",
+            "sentmail": "Sent Items",
+            "trash": "Deleted Items"
+        }
     }
 }


### PR DESCRIPTION
Hello,
I would like to add Hostinger to email providers.
Hostinger International, Ltd is an employee-owned web hosting provider and internet domain registrar. Established in 2004, Hostinger now has over 29 million users, collectively with its subsidiaries in 178 countries. 