### PR TITLE
Adding Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ DerivedData
 *.hmap
 *.xcuserstate
 *.xccheckout
+.swiftpm/
+.build/
 
 #CocoaPods
 Pods

--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,10 @@ let package = Package(
         .iOS(.v8), .macOS(.v10_10)
     ],
     products: [
-        .library(
-            name: "MailCore2",
-            targets: ["MailCore2"]),
+//        .library(
+//            name: "MailCore2",
+//            targets: ["MailCore2"]),
+        .library(name: "MailCore2", type: .dynamic, targets: ["MailCore2"])
     ],
     targets: [
         .binaryTarget(name: "MailCore2",

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
 //        .library(
 //            name: "MailCore2",
 //            targets: ["MailCore2"]),
-        .library(name: "MailCore2", type: .dynamic, targets: ["MailCore2"])
+        .library(name: "MailCore2", type: .static, targets: ["MailCore2"])
     ],
     targets: [
         .binaryTarget(name: "MailCore2",

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name: "MailCore2",
-                      url: "https://downloads.maddux.cloud/mailcore2-apple-xcframework/MailCore2-2020-09-17.xcframework.zip",
-                      checksum: "9ac3688a216e9c38dac7f5ddbfa89d314674da7f7f390d366774d218e9955452")
+                      url: "https://downloads.maddux.cloud/mailcore2-apple-xcframework/MailCore2-2020-09-24.xcframework.zip",
+                      checksum: "c3479968c758094165fb0b4de5ca7dd9f8aafac423388c51406c447f69a1b853")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "mailcore2",
+    name: "MailCore2",
     platforms: [
         .iOS(.v8), .macOS(.v10_10)
     ],
@@ -15,7 +15,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name: "MailCore2",
-                      url: "https://downloads.maddux.cloud/mailcore2-apple-xcframework/mailcore2-latest.xcframework.zip",
-                      checksum: "73ad593ac65fa6717e914f3f53302bd9064ef027e168676ae52f8295a6057047")
+                      url: "https://downloads.maddux.cloud/mailcore2-apple-xcframework/MailCore2-latest.xcframework.zip",
+                      checksum: "9ac3688a216e9c38dac7f5ddbfa89d314674da7f7f390d366774d218e9955452")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name: "MailCore2",
-                      url: "https://downloads.maddux.cloud/mailcore2-apple-xcframework/MailCore2-latest.xcframework.zip",
+                      url: "https://downloads.maddux.cloud/mailcore2-apple-xcframework/MailCore2-2020-09-17.xcframework.zip",
                       checksum: "9ac3688a216e9c38dac7f5ddbfa89d314674da7f7f390d366774d218e9955452")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -9,10 +9,9 @@ let package = Package(
         .iOS(.v8), .macOS(.v10_10)
     ],
     products: [
-//        .library(
-//            name: "MailCore2",
-//            targets: ["MailCore2"]),
-        .library(name: "MailCore2", type: .static, targets: ["MailCore2"])
+        .library(
+            name: "MailCore2",
+            targets: ["MailCore2"]),
     ],
     targets: [
         .binaryTarget(name: "MailCore2",

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name: "MailCore2",
-                      url: "http://64.227.19.239/mailcore2-apple-xcframework/mailcore2-latest.xcframework.zip",
-                      checksum: "847b486bf00cd5eeb812e3297f963d9281bc121bdd8278837614dcc46895c0ea")
+                      url: "https://downloads.maddux.cloud/mailcore2-apple-xcframework/mailcore2-latest.xcframework.zip",
+                      checksum: "73ad593ac65fa6717e914f3f53302bd9064ef027e168676ae52f8295a6057047")
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "mailcore2",
+    platforms: [
+        .iOS(.v8), .macOS(.v10_10)
+    ],
+    products: [
+        .library(
+            name: "MailCore2",
+            targets: ["MailCore2"]),
+    ],
+    targets: [
+        .binaryTarget(name: "MailCore2",
+                      url: "http://64.227.19.239/mailcore2-apple-xcframework/mailcore2-latest.xcframework.zip",
+                      checksum: "847b486bf00cd5eeb812e3297f963d9281bc121bdd8278837614dcc46895c0ea")
+    ]
+)

--- a/build-mac/README.md
+++ b/build-mac/README.md
@@ -18,7 +18,7 @@ then
 else
     FRAMEWORK_PATH="$CODESIGNING_FOLDER_PATH"/Frameworks/MailCore.framework
 fi
-echo "Signing framework at: $FRAMEWORK_PATH
+echo "Signing framework at: $FRAMEWORK_PATH"
 /usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$FRAMEWORK_PATH"
 ```
 [![Swift Package Manger Compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager/)

--- a/build-mac/README.md
+++ b/build-mac/README.md
@@ -1,3 +1,21 @@
+### Swift Package Manager ###
+
+MailCore 2 is available through [Swift Package Manager](https://swift.org/package-manager/).
+
+1. In Xcode click `File` -> `Swift Packages` -> `Add Package Dependency...`
+2. Paste the following URL: `https://github.com/MailCore/mailcore2`
+3. Click `Next` -> `Next` -> `Finish`
+
+**The following steps are to resolve an issue with the current version of Xcode 12, once the issue is fixed they will be unnecessary and removed.**
+
+4. Select `<YOUR_PROJECT>` -> `<YOUR_TARGET>` -> `Build Phases` 
+5. Click  `+` -> `New Copy Files Phase`, then change `Destination` to `Frameworks` in new build phase
+6. Click `+` -> `New Run Script Phase`, then paste the script box:
+```
+/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$CODESIGNING_FOLDER_PATH"/Frameworks/MailCore.framework
+```
+[![Swift Package Manger Compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager/)
+
 ### Carthage ###
 
 MailCore 2 is available through [Carthage](https://github.com/Carthage/Carthage).
@@ -24,6 +42,8 @@ pod 'mailcore2-ios'
 ```
 pod 'mailcore2-osx'
 ```
+
+[![CocoaPods Compatible](https://img.shields.io/badge/CocoaPods-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 ### Binary ###
 

--- a/build-mac/README.md
+++ b/build-mac/README.md
@@ -12,7 +12,14 @@ MailCore 2 is available through [Swift Package Manager](https://swift.org/packag
 5. Click  `+` -> `New Copy Files Phase`, then change `Destination` to `Frameworks` in new build phase
 6. Click `+` -> `New Run Script Phase`, then paste the script box:
 ```
-/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$CODESIGNING_FOLDER_PATH"/Frameworks/MailCore.framework
+if [ "$PLATFORM_NAME" == "macosx" ]
+then
+    FRAMEWORK_PATH="$CODESIGNING_FOLDER_PATH"/Contents/Frameworks/MailCore.framework/Versions/A/MailCore
+else
+    FRAMEWORK_PATH="$CODESIGNING_FOLDER_PATH"/Frameworks/MailCore.framework
+fi
+echo "Signing framework at: $FRAMEWORK_PATH
+/usr/bin/codesign --force --sign ${EXPANDED_CODE_SIGN_IDENTITY} --preserve-metadata=identifier,entitlements "$FRAMEWORK_PATH"
 ```
 [![Swift Package Manger Compatible](https://img.shields.io/badge/SPM-compatible-4BC51D.svg?style=flat)](https://swift.org/package-manager/)
 

--- a/scripts/build-mailcore2-xcframework-spm.sh
+++ b/scripts/build-mailcore2-xcframework-spm.sh
@@ -8,8 +8,8 @@ cd ../
 MAILCORE_DIR="`pwd`"
 BUILD_DIR="$MAILCORE_DIR/.build"
 DATE="`date +"%Y-%m-%d"`"
-FRAMEWORK_NAME="mailcore2-$DATE.xcframework"
-ARCHIVE_NAME="$FRAMEWORK_NAME.zip"
+FRAMEWORK_NAME="MailCore2.xcframework"
+ARCHIVE_NAME="MailCore2-$DATE.xcframework.zip"
 
 cd $BUILD_DIR
 

--- a/scripts/build-mailcore2-xcframework-spm.sh
+++ b/scripts/build-mailcore2-xcframework-spm.sh
@@ -12,6 +12,7 @@ FRAMEWORK_NAME="MailCore2.xcframework"
 ARCHIVE_NAME="MailCore2-$DATE.xcframework.zip"
 
 cd $BUILD_DIR
+rm "$BUILD_DIR/$ARCHIVE_NAME"
 
 # Prepare for Distribution
 zip -r -X "$ARCHIVE_NAME" "$FRAMEWORK_NAME"

--- a/scripts/build-mailcore2-xcframework-spm.sh
+++ b/scripts/build-mailcore2-xcframework-spm.sh
@@ -5,18 +5,39 @@ cd "$(dirname "$0")"
 ./build-mailcore2-xcframework.sh
 
 cd ../
+
 MAILCORE_DIR="`pwd`"
 BUILD_DIR="$MAILCORE_DIR/.build"
 DATE="`date +"%Y-%m-%d"`"
 FRAMEWORK_NAME="MailCore2.xcframework"
 ARCHIVE_NAME="MailCore2-$DATE.xcframework.zip"
+MANIFEST_PATH="$MAILCORE_DIR/Package.swift"
+BASE_URL="https://downloads.maddux.cloud/mailcore2-apple-xcframework"
+FULL_URL="$BASE_URL/$ARCHIVE_NAME"
+SUCCESS_MESSAGE="
+-------------------
+File saved at: $BUILD_DIR/$ARCHIVE_NAME
+SPM Update Instructions:
+1. Upload new file to $FULL_URL
+2. Commit & Push changes to Package.swift
+3. Create new release
+-------------------"
 
-cd $BUILD_DIR
-rm "$BUILD_DIR/$ARCHIVE_NAME"
+# Make sure xcframework export was successful
+if [[ -d "$BUILD_DIR/$FRAMEWORK_NAME" ]]; then
+    cd $BUILD_DIR
+    
+    # Clear previous archive
+    rm "$BUILD_DIR/$ARCHIVE_NAME"
 
-# Prepare for Distribution
-zip -r -X "$ARCHIVE_NAME" "$FRAMEWORK_NAME"
-CHECKSUM="`swift package compute-checksum "$ARCHIVE_NAME"`"
+    # Prepare for Distribution
+    zip -r -X "$ARCHIVE_NAME" "$FRAMEWORK_NAME"
+    CHECKSUM="`swift package compute-checksum "$ARCHIVE_NAME"`"
 
-echo "XCFramework Zip exported to: $BUILD_DIR/$ARCHIVE_NAME"
-echo "Checksum: $CHECKSUM"
+    # Update Package.swift manifest file
+    sed -i.bak "s~url: \"\(.*\)\"~url: \"$FULL_URL\"~g" $MANIFEST_PATH
+    sed -i.bak "s~checksum: \"\(.*\)\"~checksum: \"$CHECKSUM\"~g" $MANIFEST_PATH
+    rm $MANIFEST_PATH.bak
+    
+    echo "$SUCCESS_MESSAGE"
+fi

--- a/scripts/build-mailcore2-xcframework-spm.sh
+++ b/scripts/build-mailcore2-xcframework-spm.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Create XCFramework
+cd "$(dirname "$0")"
+./build-mailcore2-xcframework.sh
+
+cd ../
+MAILCORE_DIR="`pwd`"
+BUILD_DIR="$MAILCORE_DIR/.build"
+DATE="`date +"%Y-%m-%d"`"
+FRAMEWORK_NAME="mailcore2-$DATE.xcframework"
+ARCHIVE_NAME="$FRAMEWORK_NAME.zip"
+
+cd $BUILD_DIR
+
+# Prepare for Distribution
+zip -r -X "$ARCHIVE_NAME" "$FRAMEWORK_NAME"
+CHECKSUM="`swift package compute-checksum "$ARCHIVE_NAME"`"
+
+echo "XCFramework Zip exported to: $BUILD_DIR/$ARCHIVE_NAME"
+echo "Checksum: $CHECKSUM"

--- a/scripts/build-mailcore2-xcframework.sh
+++ b/scripts/build-mailcore2-xcframework.sh
@@ -8,6 +8,7 @@ BUILD_DIR="$MAILCORE_DIR/.build"
 FRAMEWORK_NAME="MailCore2.xcframework"
 
 mkdir $BUILD_DIR
+rm -rf "$BUILD_DIR/$FRAMEWORK_NAME"
 
 cd build-mac
 

--- a/scripts/build-mailcore2-xcframework.sh
+++ b/scripts/build-mailcore2-xcframework.sh
@@ -64,5 +64,3 @@ xcodebuild -create-xcframework \
 rm -rf "$BUILD_DIR/mailcore2.macOS.xcarchive"
 rm -rf "$BUILD_DIR/mailcore2.iOS-Simulator.xcarchive"
 rm -rf "$BUILD_DIR/mailcore2.iOS.xcarchive"
-
-echo "XCFramework exported to: $BUILD_DIR/$FRAMEWORK_NAME"

--- a/scripts/build-mailcore2-xcframework.sh
+++ b/scripts/build-mailcore2-xcframework.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+
+cd "$(dirname "$0")"
+cd ../
+
+MAILCORE_DIR="`pwd`"
+BUILD_DIR="$MAILCORE_DIR/.build"
+DATE="`date +"%Y-%m-%d"`"
+FRAMEWORK_NAME="mailcore2-$DATE.xcframework.zip"
+
+mkdir $BUILD_DIR
+
+cd build-mac
+
+# Build Mac Archive - ORIG
+#xcodebuild archive -scheme "mailcore osx" \
+#    -destination "platform=OS X,arch=x86_64" \
+#    -archivePath "$BUILD_DIR/mailcore2.macOS.xcarchive" \
+#    SKIP_INSTALL=NO \
+#    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+# Build Mac Archive
+xcodebuild archive -scheme "mailcore osx" \
+    -arch "x86_64" \
+    -archivePath "$BUILD_DIR/mailcore2.macOS.xcarchive" \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+    
+# Build iOS Archive
+xcodebuild archive -scheme "mailcore ios" \
+    -destination "generic/platform=iOS" \
+    -archivePath "$BUILD_DIR/mailcore2.iOS.xcarchive" \
+    -sdk iphoneos \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+    
+# Build iOS Simulator Archive - ORIG
+#xcodebuild archive -scheme "mailcore ios" \
+#    -destination "platform=iOS Simulator,name=iPhone 11" \
+#    -archivePath "$BUILD_DIR/mailcore2.iOS-Simulator.xcarchive" \
+#    -sdk iphonesimulator \
+#    SKIP_INSTALL=NO \
+#    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+# Build iOS Simulator Archive
+xcodebuild archive -scheme "mailcore ios" \
+    -arch "x86_64" \
+    -archivePath "$BUILD_DIR/mailcore2.iOS-Simulator.xcarchive" \
+    -sdk iphonesimulator \
+    SKIP_INSTALL=NO \
+    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+# Build Mac Catalyst Archive - UNCOMMENT ONCE MAC CATALYST BUILDING IS FIXED
+#xcodebuild archive -scheme "mailcore ios" \
+#    -destination "platform=macOS,variant=Mac Catalyst" \
+#    -archivePath "$BUILD_DIR/mailcore2.macOS-Catalyst.xcarchive" \
+#    -sdk ???? \
+#    SKIP_INSTALL=NO \
+#    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+cd $BUILD_DIR
+
+# Create Combined XCArchive - REMOVE ONCE MAC CATALYST BUILDING IS FIXED
+xcodebuild -create-xcframework \
+	-framework "mailcore2.macOS.xcarchive/Products/Frameworks/MailCore.framework" \
+	-framework "mailcore2.iOS-Simulator.xcarchive/Products/Frameworks/MailCore.framework" \
+	-framework "mailcore2.iOS.xcarchive/Products/Frameworks/MailCore.framework" \
+	-output "mailcore2.xcframework"
+
+# Create Combine XCArchive - UNCOMMENT ONCE MAC CATALYST BUILDING IS FIXED
+# xcodebuild -create-xcframework \
+# 	-framework "$BUILD_DIR/mailcore2.macOS.xcarchive/Products/Frameworks/MailCore.framework" \
+# 	-framework "$BUILD_DIR/mailcore2.iOS-Simulator.xcarchive/Products/Frameworks/MailCore.framework" \
+# 	-framework "$BUILD_DIR/mailcore2.iOS.xcarchive/Products/Frameworks/MailCore.framework" \
+# 	-framework "$BUILD_DIR/mailcore2.macOS-Catalyst.xcarchive/Products/Frameworks/MailCore.framework"
+# 	-output "$BUILD_DIR/mailcore2.xcframework"
+
+# Prepare for Distribution
+zip -r -X "$FRAMEWORK_NAME" "mailcore2.xcframework"
+CHECKSUM="`swift package compute-checksum "$BUILD_DIR/$FRAMEWORK_NAME"`"
+
+# Clean Up
+rm -rf "$BUILD_DIR/mailcore2.macOS.xcarchive"
+rm -rf "$BUILD_DIR/mailcore2.iOS-Simulator.xcarchive"
+rm -rf "$BUILD_DIR/mailcore2.iOS.xcarchive"
+rm -rf "$BUILD_DIR/mailcore2.xcframework"
+
+echo "XCFramework exported to: $BUILD_DIR/$FRAMEWORK_NAME"
+echo "Checksum: $CHECKSUM"

--- a/scripts/build-mailcore2-xcframework.sh
+++ b/scripts/build-mailcore2-xcframework.sh
@@ -6,18 +6,11 @@ cd ../
 MAILCORE_DIR="`pwd`"
 BUILD_DIR="$MAILCORE_DIR/.build"
 DATE="`date +"%Y-%m-%d"`"
-FRAMEWORK_NAME="mailcore2-$DATE.xcframework.zip"
+FRAMEWORK_NAME="mailcore2-$DATE.xcframework"
 
 mkdir $BUILD_DIR
 
 cd build-mac
-
-# Build Mac Archive - ORIG
-#xcodebuild archive -scheme "mailcore osx" \
-#    -destination "platform=OS X,arch=x86_64" \
-#    -archivePath "$BUILD_DIR/mailcore2.macOS.xcarchive" \
-#    SKIP_INSTALL=NO \
-#    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
 # Build Mac Archive
 xcodebuild archive -scheme "mailcore osx" \
@@ -33,14 +26,6 @@ xcodebuild archive -scheme "mailcore ios" \
     -sdk iphoneos \
     SKIP_INSTALL=NO \
     BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-    
-# Build iOS Simulator Archive - ORIG
-#xcodebuild archive -scheme "mailcore ios" \
-#    -destination "platform=iOS Simulator,name=iPhone 11" \
-#    -archivePath "$BUILD_DIR/mailcore2.iOS-Simulator.xcarchive" \
-#    -sdk iphonesimulator \
-#    SKIP_INSTALL=NO \
-#    BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
 # Build iOS Simulator Archive
 xcodebuild archive -scheme "mailcore ios" \
@@ -65,7 +50,7 @@ xcodebuild -create-xcframework \
 	-framework "mailcore2.macOS.xcarchive/Products/Frameworks/MailCore.framework" \
 	-framework "mailcore2.iOS-Simulator.xcarchive/Products/Frameworks/MailCore.framework" \
 	-framework "mailcore2.iOS.xcarchive/Products/Frameworks/MailCore.framework" \
-	-output "mailcore2.xcframework"
+	-output "$FRAMEWORK_NAME"
 
 # Create Combine XCArchive - UNCOMMENT ONCE MAC CATALYST BUILDING IS FIXED
 # xcodebuild -create-xcframework \
@@ -75,15 +60,9 @@ xcodebuild -create-xcframework \
 # 	-framework "$BUILD_DIR/mailcore2.macOS-Catalyst.xcarchive/Products/Frameworks/MailCore.framework"
 # 	-output "$BUILD_DIR/mailcore2.xcframework"
 
-# Prepare for Distribution
-zip -r -X "$FRAMEWORK_NAME" "mailcore2.xcframework"
-CHECKSUM="`swift package compute-checksum "$BUILD_DIR/$FRAMEWORK_NAME"`"
-
 # Clean Up
 rm -rf "$BUILD_DIR/mailcore2.macOS.xcarchive"
 rm -rf "$BUILD_DIR/mailcore2.iOS-Simulator.xcarchive"
 rm -rf "$BUILD_DIR/mailcore2.iOS.xcarchive"
-rm -rf "$BUILD_DIR/mailcore2.xcframework"
 
 echo "XCFramework exported to: $BUILD_DIR/$FRAMEWORK_NAME"
-echo "Checksum: $CHECKSUM"

--- a/scripts/build-mailcore2-xcframework.sh
+++ b/scripts/build-mailcore2-xcframework.sh
@@ -5,8 +5,7 @@ cd ../
 
 MAILCORE_DIR="`pwd`"
 BUILD_DIR="$MAILCORE_DIR/.build"
-DATE="`date +"%Y-%m-%d"`"
-FRAMEWORK_NAME="mailcore2-$DATE.xcframework"
+FRAMEWORK_NAME="MailCore2.xcframework"
 
 mkdir $BUILD_DIR
 


### PR DESCRIPTION
This Pull Request adds support for installing MailCore2 with Swift Package Manager.

In Xcode 12 SPM now supports distributing binary frameworks. In order to do that, however, it needs to be in an xcframework format. To create that and allow for SPM distribution, the following changes are included.

### New Scripts ###

Two new scripts are included in the scripts directory.

**build-mailcore2-xcframework.sh**

This script exports each target as an an xcarchive, then uses those to build MailCore.xcframework and save it under .build/. On it's own this file can be added to a project simply by dragging it to the `Frameworks, Libraries, and Embedded Content` under `General` for a target. No bridging header or build settings changes necessary. That could also be included in the Mac/iOS instructions as an installation option.

**build-mailcore2-xcframework-spm.sh**

This script first runs the above script to generate the xcframework, compresses it for SPM distribution, and computes a checksum that needs to be included in the Package.swift file.

### Package.swift ###

The package manifest.

If this PM is merged, this file would need to be updated with a new URL. Currently it points to a server where I'm hosting builds I was using for testing. That will remain up for a while, but it would be better if xcframeworks were hosted alongside the other binaries.

The checksum listed in this file would also need to be updated whenever a new build is uploaded.

### build-mac/README.md ###

This file is updated to include SPM instructions. The public Xcode 12 release currently has an issue with correctly signing binary frameworks distributed through SPM (see [this](https://forums.swift.org/t/swiftpm-binarytarget-dependency-and-code-signing/38953) thread). So there are a couple additional steps to fix that. However those should be able to be removed in the future.

### Other Notes ###

This supports Mac, iOS and the iOS Simulator. However, it doesn't yet support Apple Silicon or Catalyst. Once MailCore2 is able to be built for those they could easily be added.

Also a new release would need to be drafted after merge for it to work with Xcode.