### PR TITLE
Fix NSCoding memory leak

### DIFF
--- a/src/objc/utils/NSObject+MCO.h
+++ b/src/objc/utils/NSObject+MCO.h
@@ -81,6 +81,7 @@ MCO_NATIVE_INSTANCE->setter((mcType) getter); \
 #define MCO_SYNTHESIZE_NSCODING \
 - (instancetype) initWithCoder:(NSCoder *)coder \
 { \
+  [self release]; \
   mailcore::HashMap * serializable = MCO_FROM_OBJC(mailcore::HashMap, [coder decodeObjectForKey:@"info"]); \
   self = MCO_TO_OBJC(mailcore::Object::objectWithSerializable(serializable)); \
   [self retain]; \


### PR DESCRIPTION
I use MailCore in an iOS app. My app uses NSCoding to cache messages on disk. But I noticed a memory leak via the debugging tools. Each decoded instance leaks.

This can be reproduced with a sample project containing code like:

```objc
-(void)testCoding {
    MCOIMAPMessage *message = [[MCOIMAPMessage alloc] init];
    
    NSError *error;
    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:message requiringSecureCoding:NO error:&error];
    
    for (int i = 0; i<5; i++) {
        MCOIMAPMessage *msg = [NSKeyedUnarchiver unarchiveTopLevelObjectWithData:data error:&error];
        NSLog(@"%@", msg);
    }
}
```

Note: The test code uses automatic reference counting.

![leak](https://user-images.githubusercontent.com/1190948/122668513-b7a28080-d1b8-11eb-9a6d-aea925e4ab9f.png)

The `MCO_SYNTHESIZE_NSCODING` macro implements NSCoding.

The `initWithCoder` initializer always replaces the originally allocated instance of self with the return value of `[NSObject mco_objectWithMCObject:]` (see the `MCO_TO_OBJC` macro). In such cases the originally allocated instance should be released. This is explained in detail here:

[Apple documentation](https://developer.apple.com/library/archive/documentation/General/Conceptual/CocoaEncyclopedia/Initialization/Initialization.html)

> "After setting instance variables to valid initial values, return self unless: 
> - It was necessary to return a substituted object, in which case release the freshly allocated object first (in memory-managed code)."

I successfully tested the change in my app and my sample, but nothing else. I also didn't write any manual reference count code since 10 years so please review, if this fix makes sense.
