### PR TITLE
Replaces OSSpinLock with pthread_mutex_t

### DIFF
--- a/src/core/basetypes/MCLock.h
+++ b/src/core/basetypes/MCLock.h
@@ -9,24 +9,11 @@
 #ifndef mailcore2_MCLock_h
 #define mailcore2_MCLock_h
 
-#if __APPLE__
-
-#include <libkern/OSAtomic.h>
-
-#define MC_LOCK_TYPE OSSpinLock
-#define MC_LOCK_INITIAL_VALUE OS_SPINLOCK_INIT
-#define MC_LOCK(l) OSSpinLockLock(l)
-#define MC_UNLOCK(l) OSSpinLockUnlock(l)
-
-#else
-
 #include <pthread.h>
 
 #define MC_LOCK_TYPE pthread_mutex_t
 #define MC_LOCK_INITIAL_VALUE PTHREAD_MUTEX_INITIALIZER
 #define MC_LOCK(l) pthread_mutex_lock(l)
 #define MC_UNLOCK(l) pthread_mutex_unlock(l)
-
-#endif
 
 #endif

--- a/src/core/basetypes/MCObject.cpp
+++ b/src/core/basetypes/MCObject.cpp
@@ -33,18 +33,12 @@ Object::Object()
 
 Object::~Object()
 {
-#ifndef __APPLE__
     pthread_mutex_destroy(&mLock);
-#endif
 }
 
 void Object::init()
 {
-#if __APPLE__
-    mLock = OS_SPINLOCK_INIT;
-#else
     pthread_mutex_init(&mLock, NULL);
-#endif
     mCounter = 1;
 }
 

--- a/src/core/basetypes/MCObject.h
+++ b/src/core/basetypes/MCObject.h
@@ -57,11 +57,7 @@ namespace mailcore {
     public: // private
         
     private:
-#if __APPLE__
-        OSSpinLock mLock;
-#else
         pthread_mutex_t mLock;
-#endif
         int mCounter;
         void init();
         static void initObjectConstructors();


### PR DESCRIPTION
Fixing #1785 
pthread_mutex_t was chosen because 
1) it's already using on some platforms
2) os_unfair_lock must be allocated on the heap so it couldn't be used as c++ class member ([Concurrent Programming With GCD in Swift 3](https://developer.apple.com/videos/play/wwdc2016/720/) or [SO](https://stackoverflow.com/a/68614553))