### PR TITLE
Fix framework url of binary target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     targets: [
         .binaryTarget(name: "MailCore2",
-                      url: "https://github.com/mattmaddux/mailcore2/raw/master/bin/MailCore2-2020-09-24.xcframework.zip",
+                      url: "https://github.com/MailCore/mailcore2/raw/master/bin/MailCore2-2020-09-24.xcframework.zip",
                       checksum: "c3479968c758094165fb0b4de5ca7dd9f8aafac423388c51406c447f69a1b853")
     ]
 )


### PR DESCRIPTION
Was there a specific reason why this was pointing to another repository when the zip is also hosted in this repo?